### PR TITLE
added mamba install instructions, and a temporary fix for the conda install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ The MoSDeF-GOMC documentation is located [here](https://mosdef-gomc.readthedocs.
 
 ### Installation
 
-The MoSDeF-GOMC package is available via conda:
+The MoSDeF-GOMC package is available via conda or mamba:
 
 `conda create --name mosdef_gomc -c conda-forge mosdef-gomc`
+
+There is currently an issue building MoSDeF-GOMC version 1.0.0 with conda or conda-forge not pulling the latest conda build version. To rectify this, the user can run the additional command below or install using mamba because mamba is using the correct build.
+
+`conda install -c conda-forge sympy=1.10 garnett gsd pycifrw`
+    
+The MoSDeF-GOMC package is available via conda or mamba.
+
+`mamba install -c conda-forge mosdef-gomc`

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ The MoSDeF-GOMC documentation is located [here](https://mosdef-gomc.readthedocs.
 
 ### Installation
 
-The MoSDeF-GOMC package is available via conda or mamba:
+The MoSDeF-GOMC package is available via conda:
 
 `conda create --name mosdef_gomc -c conda-forge mosdef-gomc`
 
-There is currently an issue building MoSDeF-GOMC version 1.0.0 with conda or conda-forge not pulling the latest conda build version. To rectify this, the user can run the additional command below or install using mamba because mamba is using the correct build.
+There is currently an issue building MoSDeF-GOMC version 1.0.0 with conda or conda-forge not pulling the latest conda build version. To rectify this, the user can run the additional command below or install using mamba because mamba is using the correct build:
 
 `conda install -c conda-forge sympy=1.10 garnett gsd pycifrw`
 
-The MoSDeF-GOMC package is available via conda or mamba.
+The MoSDeF-GOMC package is available via conda or mamba:
 
 `mamba install -c conda-forge mosdef-gomc`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The MoSDeF-GOMC package is available via conda or mamba:
 There is currently an issue building MoSDeF-GOMC version 1.0.0 with conda or conda-forge not pulling the latest conda build version. To rectify this, the user can run the additional command below or install using mamba because mamba is using the correct build.
 
 `conda install -c conda-forge sympy=1.10 garnett gsd pycifrw`
-    
+
 The MoSDeF-GOMC package is available via conda or mamba.
 
 `mamba install -c conda-forge mosdef-gomc`

--- a/docs/getting_started/installation/installation.rst
+++ b/docs/getting_started/installation/installation.rst
@@ -10,6 +10,15 @@ Install with `conda <https://repo.anaconda.com/miniconda/>`_
 
     $ conda install -c conda-forge mosdef-gomc
 
+There is currently an issue building MoSDeF-GOMC version 1.0.0 with ``conda`` or ``conda-forge`` not pulling the latest ``conda`` build version. To rectify this, the user can run the additional command below or install using ``mamba`` because ``mamba`` is using the correct build.::
+
+    $ conda install -c conda-forge sympy=1.10 garnett gsd pycifrw
+
+Install with `mamba <https://github.com/mamba-org/mamba>`_
+----------------------------------------------------------
+::
+
+    $ mamba install -c conda-forge mosdef-gomc
 
 Install an editable version from the source code
 ------------------------------------------------


### PR DESCRIPTION
added mamba install instructions, and a temporary fix for the conda install, since conda/conda-forge not pulling the correct build number.