### PR TITLE
added the other order of asserted variables for test_charmm_a_few_mbuild_layers test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     - id: black
       args: [--line-length=80]
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
     - id: isort
       name: isort (python)

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - forcefield-utilities=0.2.1
   - foyer=0.11.3
   - gmso=0.9.1
-  - mbuild=0.15.1
+  - mbuild=0.16.0
   - pre-commit
   - sphinx
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - forcefield-utilities=0.2.1
   - foyer=0.11.3
   - gmso=0.9.1
-  - mbuild=0.16.0
+  - mbuild=0.15.1
   - pre-commit
   - sphinx
   - pip

--- a/mosdef_gomc/tests/test_charmm_writer.py
+++ b/mosdef_gomc/tests/test_charmm_writer.py
@@ -2026,7 +2026,7 @@ class TestCharmmWriterData(BaseTest):
 
         assert (
             str(test_value_0)
-            == "<Structure 17 atoms; 2 residues; 15 bonds; PBC (orthogonal); parametrized>"
+            == "<Structure 17 atoms; 2 residues; 15 bonds; PBC (orthogonal); parameterized>"
         )
         assert test_value_1 == {"ETO": 0.5, "ETH": 0.5}
         assert test_value_2 == {"ETO": 0.5, "ETH": 0.5}

--- a/mosdef_gomc/tests/test_charmm_writer.py
+++ b/mosdef_gomc/tests/test_charmm_writer.py
@@ -5,7 +5,6 @@ import numpy as np
 import pytest
 from foyer.forcefields import forcefields
 from mbuild import Box, Compound
-from mbuild.formats import charmm_writer
 from mbuild.lattice import load_cif
 from mbuild.utils.io import get_fn, has_foyer
 

--- a/mosdef_gomc/tests/test_charmm_writer.py
+++ b/mosdef_gomc/tests/test_charmm_writer.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from foyer.forcefields import forcefields
 from mbuild import Box, Compound
+from mosdef_gomc.formats import charmm_writer
 from mbuild.lattice import load_cif
 from mbuild.utils.io import get_fn, has_foyer
 

--- a/mosdef_gomc/tests/test_charmm_writer.py
+++ b/mosdef_gomc/tests/test_charmm_writer.py
@@ -5,10 +5,10 @@ import numpy as np
 import pytest
 from foyer.forcefields import forcefields
 from mbuild import Box, Compound
-from mosdef_gomc.formats import charmm_writer
 from mbuild.lattice import load_cif
 from mbuild.utils.io import get_fn, has_foyer
 
+from mosdef_gomc.formats import charmm_writer
 from mosdef_gomc.formats.charmm_writer import Charmm
 from mosdef_gomc.tests.base_test import BaseTest
 from mosdef_gomc.utils.conversion import (

--- a/mosdef_gomc/tests/test_gmso_charmm_writer.py
+++ b/mosdef_gomc/tests/test_gmso_charmm_writer.py
@@ -4518,10 +4518,9 @@ class TestCharmmWriterData(BaseTest):
         )
 
         assert test_topology.n_sites == 17
-        assert test_electrostatics14Scale_dict == {"ETO": 0.5, "ETH": 0.5}
-        assert test_nonBonded14Scale_dict == {"ETO": 0.5, "ETH": 0.5}
+        assert test_electrostatics14Scale_dict == {"ETO": 0.5, "ETH": 0.5} or {"ETH": 0.5, "ETO": 0.5}
+        assert test_nonBonded14Scale_dict == {"ETO": 0.5, "ETH": 0.5} or {"ETH": 0.5, "ETO": 0.5}
         assert test_residues_applied_list.sort() == ["ETO", "ETH"].sort()
-
     def test_charmm_all_residues_not_in_dict_boxes_for_simulation_1(
         self, ethane_gomc, ethanol_gomc
     ):

--- a/mosdef_gomc/tests/test_gmso_charmm_writer.py
+++ b/mosdef_gomc/tests/test_gmso_charmm_writer.py
@@ -4517,7 +4517,7 @@ class TestCharmmWriterData(BaseTest):
 
         assert test_topology.n_sites == 17
         assert test_electrostatics14Scale_dict == {"ETO": 0.5, "ETH": 0.5}
-        assert test_nonBonded14Scale_dict == {"ETO": 0.5, "ETH": 0.5} 
+        assert test_nonBonded14Scale_dict == {"ETO": 0.5, "ETH": 0.5}
         assert test_residues_applied_list.sort() == ["ETO", "ETH"].sort()
 
     def test_charmm_all_residues_not_in_dict_boxes_for_simulation_1(

--- a/mosdef_gomc/tests/test_gmso_charmm_writer.py
+++ b/mosdef_gomc/tests/test_gmso_charmm_writer.py
@@ -4510,18 +4510,16 @@ class TestCharmmWriterData(BaseTest):
             forcefield_selection={
                 ethanol_gomc.name: "oplsaa",
                 ethane_gomc.name: "oplsaa",
-                # box_reservior_3.name: "oplsaa",
             },
             residues=[ethanol_gomc.name, ethane_gomc.name],
-            # residues=[box_reservior_3.name],
             boxes_for_simulation=1,
         )
 
         assert test_topology.n_sites == 17
-        assert test_electrostatics14Scale_dict == {"ETO": 0.5, "ETH": 0.5} or {"ETH": 0.5, "ETO": 0.5}
-        assert test_nonBonded14Scale_dict == {"ETO": 0.5, "ETH": 0.5} or {"ETH": 0.5, "ETO": 0.5}
+        assert test_electrostatics14Scale_dict == {"ETO": 0.5, "ETH": 0.5}
+        assert test_nonBonded14Scale_dict == {"ETO": 0.5, "ETH": 0.5} 
         assert test_residues_applied_list.sort() == ["ETO", "ETH"].sort()
-        
+
     def test_charmm_all_residues_not_in_dict_boxes_for_simulation_1(
         self, ethane_gomc, ethanol_gomc
     ):

--- a/mosdef_gomc/tests/test_gmso_charmm_writer.py
+++ b/mosdef_gomc/tests/test_gmso_charmm_writer.py
@@ -4521,6 +4521,7 @@ class TestCharmmWriterData(BaseTest):
         assert test_electrostatics14Scale_dict == {"ETO": 0.5, "ETH": 0.5} or {"ETH": 0.5, "ETO": 0.5}
         assert test_nonBonded14Scale_dict == {"ETO": 0.5, "ETH": 0.5} or {"ETH": 0.5, "ETO": 0.5}
         assert test_residues_applied_list.sort() == ["ETO", "ETH"].sort()
+        
     def test_charmm_all_residues_not_in_dict_boxes_for_simulation_1(
         self, ethane_gomc, ethanol_gomc
     ):


### PR DESCRIPTION
- Fixed typo in the unit test, likely pushed form parmed changed
- Updated to be compatible with mbuild 0.16.0