### PR TITLE
sympy.simplify changed to symengine.sympify

### DIFF
--- a/docs/environment_docs.yml
+++ b/docs/environment_docs.yml
@@ -1,4 +1,4 @@
-name: mosdef_gomc
+name: mosdef_gomc_docs
 channels:
   - conda-forge
   - defaults
@@ -12,12 +12,17 @@ dependencies:
   - nbsphinx
   - sphinxcontrib
   - pycifrw
+  - pytest
+  - pytest-cov
   - sympy
-  - python>=3.8,<=3.9
-  - forcefield-utilities=0.2.1
-  - foyer=0.11.3
-  - gmso=0.9.1
-  - mbuild=0.15.1
+  - symengine
+  - python-symengine
+  - python>=3.9,<=3.10
+  - forcefield-utilities>=0.2.1
+  - foyer>=0.11.3
+  - gmso>=0.9.1
+  - mbuild>=0.16.0
+  - pre-commit
   - sphinx
   - pip
   - pip:

--- a/docs/getting_started/installation/installation.rst
+++ b/docs/getting_started/installation/installation.rst
@@ -50,7 +50,7 @@ To check all the file, you can run::
 Supported Python Versions
 -------------------------
 
-Python 3.9 are officially supported and tested during development and with the final product.
+Python 3.9 and 3.10 are officially supported and tested during development and with the final product.
 Python versions older than 3.9 may work, but there is no guarantee.
 
 Testing your installation

--- a/environment.yml
+++ b/environment.yml
@@ -17,8 +17,8 @@ dependencies:
   - sympy
   - symengine
   - python-symengine
-  - python>=3.8
-  - forcefield-utilities=0.2.1
+  - python>=3.9,<=3.10
+  - forcefield-utilities>=0.2.1
   - foyer>=0.11.3
   - gmso>=0.9.1
   - mbuild>=0.16.0

--- a/mosdef_gomc/utils/gmso_equation_compare.py
+++ b/mosdef_gomc/utils/gmso_equation_compare.py
@@ -4,6 +4,7 @@ import os
 # import signac
 import xml.etree.ElementTree as ET
 
+import symengine
 import sympy
 import unyt as u
 
@@ -43,7 +44,8 @@ def evaluate_nonbonded_lj_format_with_scaler(new_lj_form, base_lj_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.sympify(new_lj_form) / sympy.sympify(base_lj_form),
+                - symengine.sympify(new_lj_form)
+                / symengine.sympify(base_lj_form),
                 Rmin - sigma * two ** (1 / 6),
                 two - 2,
             ],
@@ -94,7 +96,8 @@ def evaluate_nonbonded_mie_format_with_scaler(new_mie_form, base_mie_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.sympify(new_mie_form) / sympy.sympify(base_mie_form),
+                - symengine.sympify(new_mie_form)
+                / symengine.sympify(base_mie_form),
             ],
             [eqn_ratio],
         )
@@ -144,7 +147,8 @@ def evaluate_nonbonded_exp6_format_with_scaler(new_exp6_form, base_exp6_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.sympify(new_exp6_form) / sympy.sympify(base_exp6_form),
+                - symengine.sympify(new_exp6_form)
+                / symengine.sympify(base_exp6_form),
             ],
             [eqn_ratio],
         )
@@ -362,7 +366,8 @@ def evaluate_harmonic_bond_format_with_scaler(new_bond_form, base_bond_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.sympify(new_bond_form) / sympy.sympify(base_bond_form),
+                - symengine.sympify(new_bond_form)
+                / symengine.sympify(base_bond_form),
             ],
             [eqn_ratio],
         )
@@ -407,8 +412,8 @@ def evaluate_harmonic_angle_format_with_scaler(new_angle_form, base_angle_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.sympify(new_angle_form)
-                / sympy.sympify(base_angle_form),
+                - symengine.sympify(new_angle_form)
+                / symengine.sympify(base_angle_form),
             ],
             [eqn_ratio],
         )
@@ -454,8 +459,8 @@ def evaluate_harmonic_torsion_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.sympify(new_torsion_form)
-                / sympy.sympify(base_torsion_form),
+                - symengine.sympify(new_torsion_form)
+                / symengine.sympify(base_torsion_form),
             ],
             [eqn_ratio],
         )
@@ -503,8 +508,8 @@ def evaluate_OPLS_torsion_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.sympify(new_torsion_form)
-                / sympy.sympify(base_torsion_form),
+                - symengine.sympify(new_torsion_form)
+                / symengine.sympify(base_torsion_form),
             ],
             [eqn_ratio],
         )
@@ -550,8 +555,8 @@ def evaluate_periodic_torsion_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.sympify(new_torsion_form)
-                / sympy.sympify(base_torsion_form),
+                - symengine.sympify(new_torsion_form)
+                / symengine.sympify(base_torsion_form),
             ],
             [eqn_ratio],
         )
@@ -597,8 +602,8 @@ def evaluate_RB_torsion_format_with_scaler(new_torsion_form, base_torsion_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.sympify(new_torsion_form)
-                / sympy.sympify(base_torsion_form),
+                - symengine.sympify(new_torsion_form)
+                / symengine.sympify(base_torsion_form),
             ],
             [eqn_ratio],
         )
@@ -644,8 +649,8 @@ def evaluate_harmonic_improper_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.sympify(new_improper_form)
-                / sympy.sympify(base_improper_form),
+                - symengine.sympify(new_improper_form)
+                / symengine.sympify(base_improper_form),
             ],
             [eqn_ratio],
         )
@@ -691,8 +696,8 @@ def evaluate_periodic_improper_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.sympify(new_improper_form)
-                / sympy.sympify(base_improper_form),
+                - symengine.sympify(new_improper_form)
+                / symengine.sympify(base_improper_form),
             ],
             [eqn_ratio],
         )


### PR DESCRIPTION
changed environment packages, docs updated to Python 3.9 and 3.10, and sympy.simplify changed to symengine.sympify to speed up the calcs.