### PR TITLE
Turn off docker build in CI.yml until dockerfile is fixed

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     needs: Mambaforge-pytest
     name: 'Build Docker Image'
-    if: ${{ false }} 
+    if: ${{ false }}
 
     steps:
       - name: Set up Docker Buildx

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     needs: Mambaforge-pytest
     name: 'Build Docker Image'
-    if: github.event_name != 'pull_request'
+    if: ${{ false }} 
 
     steps:
       - name: Set up Docker Buildx


### PR DESCRIPTION
Since the current dockerfile is failing, I think we should have the docker build (in CI.yml) turned off for now. We can turn it back on once we have the dockerfile figured out.