### PR TITLE
added more checks for potential k-scalars

### DIFF
--- a/mosdef_gomc/formats/gmso_charmm_writer.py
+++ b/mosdef_gomc/formats/gmso_charmm_writer.py
@@ -3495,10 +3495,10 @@ class Charmm:
                         # Check if OPLSTorsionPotential with 0.5
                         # NOTE: It does not compare if 0.5 and 1/2 (rounding error)
                         OPLSTorsionPotential_form_with_scalar = (
-                            "1/2 * k0 + " 
-                            "1/2 * k1 * (1 + cos(phi)) + " 
-                            "1/2 * k2 * (1 - cos(2*phi)) + " 
-                            "1/2 * k3 * (1 + cos(3*phi)) + " 
+                            "1/2 * k0 + "
+                            "1/2 * k1 * (1 + cos(phi)) + "
+                            "1/2 * k2 * (1 - cos(2*phi)) + "
+                            "1/2 * k3 * (1 + cos(3*phi)) + "
                             "1/2 * k4 * (1 - cos(4*phi))"
                         )
                         [
@@ -3518,10 +3518,10 @@ class Charmm:
                         # Check if OPLSTorsionPotential with 0.5
                         # note it does not compare if 0.5 and 1/2 (rounding error)
                         OPLSTorsionPotential_form_with_scalar = (
-                            "0.5 * k0 + " 
-                            "0.5 * k1 * (1 + cos(phi)) + " 
-                            "0.5 * k2 * (1 - cos(2*phi)) + " 
-                            "0.5 * k3 * (1 + cos(3*phi)) + " 
+                            "0.5 * k0 + "
+                            "0.5 * k1 * (1 + cos(phi)) + "
+                            "0.5 * k2 * (1 - cos(2*phi)) + "
+                            "0.5 * k3 * (1 + cos(3*phi)) + "
                             "0.5 * k4 * (1 - cos(4*phi))"
                         )
                         [

--- a/mosdef_gomc/formats/gmso_charmm_writer.py
+++ b/mosdef_gomc/formats/gmso_charmm_writer.py
@@ -3485,16 +3485,43 @@ class Charmm:
 
                     dihedral_type_str_iter = None
                     dihedral_eqn_scalar_iter = None
+
+                    # Check if OPLSTorsionPotential with 0.5
+                    # NOTE: It does not compare if 0.5 and 1/2 (rounding error)
                     if (
                         dihedral_type_str_iter is None
                         and dihedral_eqn_scalar_iter is None
                     ):
-                        # Check if OPLSTorsionPotential
+                        # Check if OPLSTorsionPotential with 0.5
+                        # NOTE: It does not compare if 0.5 and 1/2 (rounding error)
                         OPLSTorsionPotential_form_with_scalar = (
-                            "0.5 * k0 + "
-                            "0.5 * k1 * (1 + cos(phi)) + "
-                            "0.5 * k2 * (1 - cos(2*phi)) + "
-                            "0.5 * k3 * (1 + cos(3*phi)) + "
+                            "1/2 * k0 + " 
+                            "1/2 * k1 * (1 + cos(phi)) + " 
+                            "1/2 * k2 * (1 - cos(2*phi)) + " 
+                            "1/2 * k3 * (1 + cos(3*phi)) + " 
+                            "1/2 * k4 * (1 - cos(4*phi))"
+                        )
+                        [
+                            dihedral_type_str_iter,
+                            dihedral_eqn_scalar_iter,
+                        ] = evaluate_OPLS_torsion_format_with_scaler(
+                            dihedral_type_x.expression,
+                            OPLSTorsionPotential_form_with_scalar,
+                        )
+
+                    # Check if OPLSTorsionPotential with 0.5
+                    # NOTE: It does not compare if 0.5 and 1/2 (rounding error)
+                    if (
+                        dihedral_type_str_iter is None
+                        and dihedral_eqn_scalar_iter is None
+                    ):
+                        # Check if OPLSTorsionPotential with 0.5
+                        # note it does not compare if 0.5 and 1/2 (rounding error)
+                        OPLSTorsionPotential_form_with_scalar = (
+                            "0.5 * k0 + " 
+                            "0.5 * k1 * (1 + cos(phi)) + " 
+                            "0.5 * k2 * (1 - cos(2*phi)) + " 
+                            "0.5 * k3 * (1 + cos(3*phi)) + " 
                             "0.5 * k4 * (1 - cos(4*phi))"
                         )
                         [

--- a/mosdef_gomc/tests/test_gmso_charmm_writer.py
+++ b/mosdef_gomc/tests/test_gmso_charmm_writer.py
@@ -6575,17 +6575,17 @@ class TestCharmmWriterData(BaseTest):
             out_gomc = fp.readlines()
             for i, line in enumerate(out_gomc):
                 if (
-                        "! type_1" in line
-                        and "type_2" in line
-                        and "type_3" in line
-                        and "type_4" in line
-                        and "Kchi" in line
-                        and "n" in line
-                        and "delta" in line
-                        and "extended_type_1" in line
-                        and "extended_type_2" in line
-                        and "extended_type_3" in line
-                        and "extended_type_4" in line
+                    "! type_1" in line
+                    and "type_2" in line
+                    and "type_3" in line
+                    and "type_4" in line
+                    and "Kchi" in line
+                    and "n" in line
+                    and "delta" in line
+                    and "extended_type_1" in line
+                    and "extended_type_2" in line
+                    and "extended_type_3" in line
+                    and "extended_type_4" in line
                 ):
                     dihedrals_read = True
                     dihedral_types = [
@@ -6595,11 +6595,11 @@ class TestCharmmWriterData(BaseTest):
                     ]
                     for j in range(0, len(dihedral_types)):
                         assert (
-                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
+                            len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
                         )
                         assert (
-                                out_gomc[i + 1 + j].split("!")[0].split()[0:7]
-                                == dihedral_types[j]
+                            out_gomc[i + 1 + j].split("!")[0].split()[0:7]
+                            == dihedral_types[j]
                         )
 
                 else:
@@ -6691,17 +6691,17 @@ class TestCharmmWriterData(BaseTest):
             out_gomc = fp.readlines()
             for i, line in enumerate(out_gomc):
                 if (
-                        "! type_1" in line
-                        and "type_2" in line
-                        and "type_3" in line
-                        and "type_4" in line
-                        and "Kchi" in line
-                        and "n" in line
-                        and "delta" in line
-                        and "extended_type_1" in line
-                        and "extended_type_2" in line
-                        and "extended_type_3" in line
-                        and "extended_type_4" in line
+                    "! type_1" in line
+                    and "type_2" in line
+                    and "type_3" in line
+                    and "type_4" in line
+                    and "Kchi" in line
+                    and "n" in line
+                    and "delta" in line
+                    and "extended_type_1" in line
+                    and "extended_type_2" in line
+                    and "extended_type_3" in line
+                    and "extended_type_4" in line
                 ):
                     dihedrals_read = True
                     dihedral_types = [
@@ -6711,11 +6711,11 @@ class TestCharmmWriterData(BaseTest):
                     ]
                     for j in range(0, len(dihedral_types)):
                         assert (
-                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
+                            len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
                         )
                         assert (
-                                out_gomc[i + 1 + j].split("!")[0].split()[0:7]
-                                == dihedral_types[j]
+                            out_gomc[i + 1 + j].split("!")[0].split()[0:7]
+                            == dihedral_types[j]
                         )
 
                 else:
@@ -6724,7 +6724,9 @@ class TestCharmmWriterData(BaseTest):
         assert dihedrals_read
 
     # test the gmso OPLS dihderal input with half times 1 OPLS torsion values
-    def test_save_gmso_OPLS_dihedral_half_times_1_gomc_ff(self, two_propanol_ua):
+    def test_save_gmso_OPLS_dihedral_half_times_1_gomc_ff(
+        self, two_propanol_ua
+    ):
         box_0 = mb.fill_box(
             compound=[two_propanol_ua], n_compounds=[1], box=[4, 4, 4]
         )
@@ -6782,7 +6784,9 @@ class TestCharmmWriterData(BaseTest):
         assert dihedrals_read
 
     # test the gmso OPLS dihderal input with 0.5 times 2 OPLS torsion values
-    def test_save_gmso_OPLS_dihedral_half_times_2_gomc_ff(self, two_propanol_ua):
+    def test_save_gmso_OPLS_dihedral_half_times_2_gomc_ff(
+        self, two_propanol_ua
+    ):
         box_0 = mb.fill_box(
             compound=[two_propanol_ua], n_compounds=[1], box=[4, 4, 4]
         )
@@ -6807,17 +6811,17 @@ class TestCharmmWriterData(BaseTest):
             out_gomc = fp.readlines()
             for i, line in enumerate(out_gomc):
                 if (
-                        "! type_1" in line
-                        and "type_2" in line
-                        and "type_3" in line
-                        and "type_4" in line
-                        and "Kchi" in line
-                        and "n" in line
-                        and "delta" in line
-                        and "extended_type_1" in line
-                        and "extended_type_2" in line
-                        and "extended_type_3" in line
-                        and "extended_type_4" in line
+                    "! type_1" in line
+                    and "type_2" in line
+                    and "type_3" in line
+                    and "type_4" in line
+                    and "Kchi" in line
+                    and "n" in line
+                    and "delta" in line
+                    and "extended_type_1" in line
+                    and "extended_type_2" in line
+                    and "extended_type_3" in line
+                    and "extended_type_4" in line
                 ):
                     dihedrals_read = True
                     dihedral_types = [
@@ -6827,11 +6831,11 @@ class TestCharmmWriterData(BaseTest):
                     ]
                     for j in range(0, len(dihedral_types)):
                         assert (
-                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
+                            len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
                         )
                         assert (
-                                out_gomc[i + 1 + j].split("!")[0].split()[0:7]
-                                == dihedral_types[j]
+                            out_gomc[i + 1 + j].split("!")[0].split()[0:7]
+                            == dihedral_types[j]
                         )
 
                 else:
@@ -6840,7 +6844,9 @@ class TestCharmmWriterData(BaseTest):
         assert dihedrals_read
 
     # test the gmso periodic dihderal input add k (bonds, angles, dihedrals times 1/2)
-    def test_save_gmso_periodic_dihedral_gomc_ff_all_ks_times_half(self, two_propanol_ua):
+    def test_save_gmso_periodic_dihedral_gomc_ff_all_ks_times_half(
+        self, two_propanol_ua
+    ):
         box_0 = mb.fill_box(
             compound=[two_propanol_ua], n_compounds=[1], box=[4, 4, 4]
         )
@@ -6861,7 +6867,6 @@ class TestCharmmWriterData(BaseTest):
         charmm.write_inp()
 
         with open("gmso_periodic_dihedral_gomc.inp", "r") as fp:
-
             masses_read = False
             bonds_read = False
             angles_read = False
@@ -6869,9 +6874,9 @@ class TestCharmmWriterData(BaseTest):
             out_gomc = fp.readlines()
             for i, line in enumerate(out_gomc):
                 if (
-                        "! atom_types" in line
-                        and "mass" in line
-                        and "atomClass_ResidueName" in line
+                    "! atom_types" in line
+                    and "mass" in line
+                    and "atomClass_ResidueName" in line
                 ):
                     masses_read = True
                     atom_types_1 = [
@@ -6889,23 +6894,23 @@ class TestCharmmWriterData(BaseTest):
 
                     for j in range(0, len(atom_types_1)):
                         assert (
-                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 3
+                            len(out_gomc[i + 1 + j].split("!")[0].split()) == 3
                         )
                         assert (
-                                out_gomc[i + 1 + j].split("!")[0].split()[0:3]
-                                == atom_types_1[j]
+                            out_gomc[i + 1 + j].split("!")[0].split()[0:3]
+                            == atom_types_1[j]
                         )
                         assert (
-                                out_gomc[i + 1 + j].split()[4:5] == atom_types_2[j]
+                            out_gomc[i + 1 + j].split()[4:5] == atom_types_2[j]
                         )
 
                 elif (
-                        "! type_1" in line
-                        and "type_2" in line
-                        and "Kb" in line
-                        and "b0" in line
-                        and "extended_type_1" in line
-                        and "extended_type_2" in line
+                    "! type_1" in line
+                    and "type_2" in line
+                    and "Kb" in line
+                    and "b0" in line
+                    and "extended_type_1" in line
+                    and "extended_type_2" in line
                 ):
                     bonds_read = True
                     bond_types = [
@@ -6917,14 +6922,14 @@ class TestCharmmWriterData(BaseTest):
                     total_bonds_evaluated_reorg = []
                     for j in range(0, len(bond_types)):
                         assert (
-                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 4
+                            len(out_gomc[i + 1 + j].split("!")[0].split()) == 4
                         )
 
                         if (
-                                out_gomc[i + 1 + j].split("!")[0].split()[0:4]
-                                == bond_types[0]
-                                or bond_types[1]
-                                or bond_types[2]
+                            out_gomc[i + 1 + j].split("!")[0].split()[0:4]
+                            == bond_types[0]
+                            or bond_types[1]
+                            or bond_types[2]
                         ):
                             total_bonds_evaluated.append(
                                 out_gomc[i + 1 + j].split("!")[0].split()[0:4]
@@ -6935,14 +6940,14 @@ class TestCharmmWriterData(BaseTest):
                     assert total_bonds_evaluated_reorg == bond_types
 
                 elif (
-                        "! type_1 " in line
-                        and "type_2" in line
-                        and "type_3" in line
-                        and "Ktheta" in line
-                        and "Theta0" in line
-                        and "extended_type_1" in line
-                        and "extended_type_2" in line
-                        and "extended_type_3" in line
+                    "! type_1 " in line
+                    and "type_2" in line
+                    and "type_3" in line
+                    and "Ktheta" in line
+                    and "Theta0" in line
+                    and "extended_type_1" in line
+                    and "extended_type_2" in line
+                    and "extended_type_3" in line
                 ):
                     angles_read = True
                     angle_types = [
@@ -6954,13 +6959,13 @@ class TestCharmmWriterData(BaseTest):
                     total_angles_evaluated_reorg = []
                     for j in range(0, len(angle_types)):
                         assert (
-                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 5
+                            len(out_gomc[i + 1 + j].split("!")[0].split()) == 5
                         )
                         if (
-                                out_gomc[i + 1 + j].split("!")[0].split()[0:5]
-                                == angle_types[0]
-                                or angle_types[1]
-                                or angle_types[2]
+                            out_gomc[i + 1 + j].split("!")[0].split()[0:5]
+                            == angle_types[0]
+                            or angle_types[1]
+                            or angle_types[2]
                         ):
                             total_angles_evaluated.append(
                                 out_gomc[i + 1 + j].split("!")[0].split()[0:5]
@@ -6972,17 +6977,17 @@ class TestCharmmWriterData(BaseTest):
                     assert total_angles_evaluated_reorg == angle_types
 
                 elif (
-                        "! type_1" in line
-                        and "type_2" in line
-                        and "type_3" in line
-                        and "type_4" in line
-                        and "Kchi" in line
-                        and "n" in line
-                        and "delta" in line
-                        and "extended_type_1" in line
-                        and "extended_type_2" in line
-                        and "extended_type_3" in line
-                        and "extended_type_4" in line
+                    "! type_1" in line
+                    and "type_2" in line
+                    and "type_3" in line
+                    and "type_4" in line
+                    and "Kchi" in line
+                    and "n" in line
+                    and "delta" in line
+                    and "extended_type_1" in line
+                    and "extended_type_2" in line
+                    and "extended_type_3" in line
+                    and "extended_type_4" in line
                 ):
                     dihedrals_read = True
                     dihedral_types = [
@@ -6992,11 +6997,11 @@ class TestCharmmWriterData(BaseTest):
                     ]
                     for j in range(0, len(dihedral_types)):
                         assert (
-                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
+                            len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
                         )
                         assert (
-                                out_gomc[i + 1 + j].split("!")[0].split()[0:7]
-                                == dihedral_types[j]
+                            out_gomc[i + 1 + j].split("!")[0].split()[0:7]
+                            == dihedral_types[j]
                         )
 
         assert masses_read
@@ -7005,7 +7010,9 @@ class TestCharmmWriterData(BaseTest):
         assert dihedrals_read
 
     # test the gmso periodic dihderal input add k (bonds, angles, dihedrals times 1)
-    def test_save_gmso_periodic_dihedral_gomc_ff_all_ks_times_1(self, two_propanol_ua):
+    def test_save_gmso_periodic_dihedral_gomc_ff_all_ks_times_1(
+        self, two_propanol_ua
+    ):
         box_0 = mb.fill_box(
             compound=[two_propanol_ua], n_compounds=[1], box=[4, 4, 4]
         )
@@ -7026,7 +7033,6 @@ class TestCharmmWriterData(BaseTest):
         charmm.write_inp()
 
         with open("gmso_periodic_dihedral_gomc.inp", "r") as fp:
-
             masses_read = False
             bonds_read = False
             angles_read = False
@@ -7034,9 +7040,9 @@ class TestCharmmWriterData(BaseTest):
             out_gomc = fp.readlines()
             for i, line in enumerate(out_gomc):
                 if (
-                        "! atom_types" in line
-                        and "mass" in line
-                        and "atomClass_ResidueName" in line
+                    "! atom_types" in line
+                    and "mass" in line
+                    and "atomClass_ResidueName" in line
                 ):
                     masses_read = True
                     atom_types_1 = [
@@ -7054,23 +7060,23 @@ class TestCharmmWriterData(BaseTest):
 
                     for j in range(0, len(atom_types_1)):
                         assert (
-                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 3
+                            len(out_gomc[i + 1 + j].split("!")[0].split()) == 3
                         )
                         assert (
-                                out_gomc[i + 1 + j].split("!")[0].split()[0:3]
-                                == atom_types_1[j]
+                            out_gomc[i + 1 + j].split("!")[0].split()[0:3]
+                            == atom_types_1[j]
                         )
                         assert (
-                                out_gomc[i + 1 + j].split()[4:5] == atom_types_2[j]
+                            out_gomc[i + 1 + j].split()[4:5] == atom_types_2[j]
                         )
 
                 elif (
-                        "! type_1" in line
-                        and "type_2" in line
-                        and "Kb" in line
-                        and "b0" in line
-                        and "extended_type_1" in line
-                        and "extended_type_2" in line
+                    "! type_1" in line
+                    and "type_2" in line
+                    and "Kb" in line
+                    and "b0" in line
+                    and "extended_type_1" in line
+                    and "extended_type_2" in line
                 ):
                     bonds_read = True
                     bond_types = [
@@ -7082,14 +7088,14 @@ class TestCharmmWriterData(BaseTest):
                     total_bonds_evaluated_reorg = []
                     for j in range(0, len(bond_types)):
                         assert (
-                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 4
+                            len(out_gomc[i + 1 + j].split("!")[0].split()) == 4
                         )
 
                         if (
-                                out_gomc[i + 1 + j].split("!")[0].split()[0:4]
-                                == bond_types[0]
-                                or bond_types[1]
-                                or bond_types[2]
+                            out_gomc[i + 1 + j].split("!")[0].split()[0:4]
+                            == bond_types[0]
+                            or bond_types[1]
+                            or bond_types[2]
                         ):
                             total_bonds_evaluated.append(
                                 out_gomc[i + 1 + j].split("!")[0].split()[0:4]
@@ -7100,14 +7106,14 @@ class TestCharmmWriterData(BaseTest):
                     assert total_bonds_evaluated_reorg == bond_types
 
                 elif (
-                        "! type_1 " in line
-                        and "type_2" in line
-                        and "type_3" in line
-                        and "Ktheta" in line
-                        and "Theta0" in line
-                        and "extended_type_1" in line
-                        and "extended_type_2" in line
-                        and "extended_type_3" in line
+                    "! type_1 " in line
+                    and "type_2" in line
+                    and "type_3" in line
+                    and "Ktheta" in line
+                    and "Theta0" in line
+                    and "extended_type_1" in line
+                    and "extended_type_2" in line
+                    and "extended_type_3" in line
                 ):
                     angles_read = True
                     angle_types = [
@@ -7119,13 +7125,13 @@ class TestCharmmWriterData(BaseTest):
                     total_angles_evaluated_reorg = []
                     for j in range(0, len(angle_types)):
                         assert (
-                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 5
+                            len(out_gomc[i + 1 + j].split("!")[0].split()) == 5
                         )
                         if (
-                                out_gomc[i + 1 + j].split("!")[0].split()[0:5]
-                                == angle_types[0]
-                                or angle_types[1]
-                                or angle_types[2]
+                            out_gomc[i + 1 + j].split("!")[0].split()[0:5]
+                            == angle_types[0]
+                            or angle_types[1]
+                            or angle_types[2]
                         ):
                             total_angles_evaluated.append(
                                 out_gomc[i + 1 + j].split("!")[0].split()[0:5]
@@ -7137,17 +7143,17 @@ class TestCharmmWriterData(BaseTest):
                     assert total_angles_evaluated_reorg == angle_types
 
                 elif (
-                        "! type_1" in line
-                        and "type_2" in line
-                        and "type_3" in line
-                        and "type_4" in line
-                        and "Kchi" in line
-                        and "n" in line
-                        and "delta" in line
-                        and "extended_type_1" in line
-                        and "extended_type_2" in line
-                        and "extended_type_3" in line
-                        and "extended_type_4" in line
+                    "! type_1" in line
+                    and "type_2" in line
+                    and "type_3" in line
+                    and "type_4" in line
+                    and "Kchi" in line
+                    and "n" in line
+                    and "delta" in line
+                    and "extended_type_1" in line
+                    and "extended_type_2" in line
+                    and "extended_type_3" in line
+                    and "extended_type_4" in line
                 ):
                     dihedrals_read = True
                     dihedral_types = [
@@ -7157,18 +7163,17 @@ class TestCharmmWriterData(BaseTest):
                     ]
                     for j in range(0, len(dihedral_types)):
                         assert (
-                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
+                            len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
                         )
                         assert (
-                                out_gomc[i + 1 + j].split("!")[0].split()[0:7]
-                                == dihedral_types[j]
+                            out_gomc[i + 1 + j].split("!")[0].split()[0:7]
+                            == dihedral_types[j]
                         )
 
         assert masses_read
         assert bonds_read
         assert angles_read
         assert dihedrals_read
-
 
     # test the gmso periodic wildcard dihderal input
     def test_save_gmso_periodic_wildcard_dihedral_gomc_ff(

--- a/mosdef_gomc/tests/test_gmso_charmm_writer.py
+++ b/mosdef_gomc/tests/test_gmso_charmm_writer.py
@@ -6453,7 +6453,7 @@ class TestCharmmWriterData(BaseTest):
                         "gmso_spce_water_bad_charges__lorentz_combining.xml"
                     ),
                     two_propanol_ua.name: get_mosdef_gomc_fn(
-                        "gmso_two_propanol_periodic_dihedrals_ua.xml"
+                        "gmso_two_propanol_periodic_dihedrals_ua_all_bond_angles_dihedrals_k_times_half.xml"
                     ),
                 },
             )
@@ -6485,14 +6485,14 @@ class TestCharmmWriterData(BaseTest):
                         "gmso_spce_water_bad_charges__lorentz_combining.xml"
                     ),
                     two_propanol_ua.name: get_mosdef_gomc_fn(
-                        "gmso_two_propanol_periodic_dihedrals_ua.xml"
+                        "gmso_two_propanol_periodic_dihedrals_ua_all_bond_angles_dihedrals_k_times_half.xml"
                     ),
                 },
             )
 
     # **** testing the different dihedral types produce the same values and work properly ****
-    # test the gmso RB dihderal input
-    def test_save_gmso_RB_dihedral_gomc_ff(self, two_propanol_ua):
+    # test the gmso RB dihderal input with 1 times the RB torsion values
+    def test_save_gmso_RB_dihedral_times_1_gomc_ff(self, two_propanol_ua):
         box_0 = mb.fill_box(
             compound=[two_propanol_ua], n_compounds=[1], box=[4, 4, 4]
         )
@@ -6504,7 +6504,7 @@ class TestCharmmWriterData(BaseTest):
             residues=[two_propanol_ua.name],
             forcefield_selection={
                 two_propanol_ua.name: get_mosdef_gomc_fn(
-                    "gmso_two_propanol_RB_dihedrals_ua.xml"
+                    "gmso_two_propanol_RB_dihedrals_times_1_ua.xml"
                 ),
             },
             bead_to_atom_name_dict={"_CH3": "C", "_CH2": "C", "_HC": "C"},
@@ -6549,8 +6549,66 @@ class TestCharmmWriterData(BaseTest):
 
         assert dihedrals_read
 
-    # test the gmso OPLS dihderal input
-    def test_save_gmso_OPLS_dihedral_gomc_ff(self, two_propanol_ua):
+    # test the gmso RB dihderal input with 2 times the RB torsion values
+    def test_save_gmso_RB_dihedral_times_2_gomc_ff(self, two_propanol_ua):
+        box_0 = mb.fill_box(
+            compound=[two_propanol_ua], n_compounds=[1], box=[4, 4, 4]
+        )
+
+        charmm = Charmm(
+            box_0,
+            "gmso_RB_dihedral_gomc",
+            ff_filename="gmso_RB_dihedral_gomc",
+            residues=[two_propanol_ua.name],
+            forcefield_selection={
+                two_propanol_ua.name: get_mosdef_gomc_fn(
+                    "gmso_two_propanol_RB_dihedrals_times_2_ua.xml"
+                ),
+            },
+            bead_to_atom_name_dict={"_CH3": "C", "_CH2": "C", "_HC": "C"},
+            atom_type_naming_style="general",
+        )
+        charmm.write_inp()
+
+        with open("gmso_RB_dihedral_gomc.inp", "r") as fp:
+            dihedrals_read = False
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if (
+                        "! type_1" in line
+                        and "type_2" in line
+                        and "type_3" in line
+                        and "type_4" in line
+                        and "Kchi" in line
+                        and "n" in line
+                        and "delta" in line
+                        and "extended_type_1" in line
+                        and "extended_type_2" in line
+                        and "extended_type_3" in line
+                        and "extended_type_4" in line
+                ):
+                    dihedrals_read = True
+                    dihedral_types = [
+                        ["CH3", "CH", "O", "H", "-0.78427", "1", "180.0"],
+                        ["CH3", "CH", "O", "H", "-0.125036", "2", "0.0"],
+                        ["CH3", "CH", "O", "H", "0.69123", "3", "180.0"],
+                    ]
+                    for j in range(0, len(dihedral_types)):
+                        assert (
+                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
+                        )
+                        assert (
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:7]
+                                == dihedral_types[j]
+                        )
+
+                else:
+                    pass
+
+        assert dihedrals_read
+
+    # test the gmso OPLS dihderal input with 0.5 times 1 OPLS torsion values
+    def test_save_gmso_OPLS_dihedral_0_5_times_1_gomc_ff(self, two_propanol_ua):
         box_0 = mb.fill_box(
             compound=[two_propanol_ua], n_compounds=[1], box=[4, 4, 4]
         )
@@ -6562,7 +6620,7 @@ class TestCharmmWriterData(BaseTest):
             residues=[two_propanol_ua.name],
             forcefield_selection={
                 two_propanol_ua.name: get_mosdef_gomc_fn(
-                    "gmso_two_propanol_OPLS_dihedrals_ua.xml"
+                    "gmso_two_propanol_OPLS_dihedrals_0_5_times_1_ua.xml"
                 ),
             },
             bead_to_atom_name_dict={"_CH3": "C", "_CH2": "C", "_HC": "C"},
@@ -6607,20 +6665,20 @@ class TestCharmmWriterData(BaseTest):
 
         assert dihedrals_read
 
-    # test the gmso periodic dihderal input
-    def test_save_gmso_periodic_dihedral_gomc_ff(self, two_propanol_ua):
+    # test the gmso OPLS dihderal input with 0.5 times 2 OPLS torsion values
+    def test_save_gmso_OPLS_dihedral_0_5_times_2_gomc_ff(self, two_propanol_ua):
         box_0 = mb.fill_box(
             compound=[two_propanol_ua], n_compounds=[1], box=[4, 4, 4]
         )
 
         charmm = Charmm(
             box_0,
-            "gmso_periodic_dihedral_gomc",
-            ff_filename="gmso_periodic_dihedral_gomc",
+            "gmso_OPLS_dihedral_gomc",
+            ff_filename="gmso_OPLS_dihedral_gomc",
             residues=[two_propanol_ua.name],
             forcefield_selection={
                 two_propanol_ua.name: get_mosdef_gomc_fn(
-                    "gmso_two_propanol_periodic_dihedrals_ua.xml"
+                    "gmso_two_propanol_OPLS_dihedrals_0_5_times_2_ua.xml"
                 ),
             },
             bead_to_atom_name_dict={"_CH3": "C", "_CH2": "C", "_HC": "C"},
@@ -6628,7 +6686,65 @@ class TestCharmmWriterData(BaseTest):
         )
         charmm.write_inp()
 
-        with open("gmso_periodic_dihedral_gomc.inp", "r") as fp:
+        with open("gmso_OPLS_dihedral_gomc.inp", "r") as fp:
+            dihedrals_read = False
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if (
+                        "! type_1" in line
+                        and "type_2" in line
+                        and "type_3" in line
+                        and "type_4" in line
+                        and "Kchi" in line
+                        and "n" in line
+                        and "delta" in line
+                        and "extended_type_1" in line
+                        and "extended_type_2" in line
+                        and "extended_type_3" in line
+                        and "extended_type_4" in line
+                ):
+                    dihedrals_read = True
+                    dihedral_types = [
+                        ["CH3", "CH", "O", "H", "-0.78427", "1", "180.0"],
+                        ["CH3", "CH", "O", "H", "-0.125036", "2", "0.0"],
+                        ["CH3", "CH", "O", "H", "0.69123", "3", "180.0"],
+                    ]
+                    for j in range(0, len(dihedral_types)):
+                        assert (
+                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
+                        )
+                        assert (
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:7]
+                                == dihedral_types[j]
+                        )
+
+                else:
+                    pass
+
+        assert dihedrals_read
+
+    # test the gmso OPLS dihderal input with half times 1 OPLS torsion values
+    def test_save_gmso_OPLS_dihedral_half_times_1_gomc_ff(self, two_propanol_ua):
+        box_0 = mb.fill_box(
+            compound=[two_propanol_ua], n_compounds=[1], box=[4, 4, 4]
+        )
+
+        charmm = Charmm(
+            box_0,
+            "gmso_OPLS_dihedral_gomc",
+            ff_filename="gmso_OPLS_dihedral_gomc",
+            residues=[two_propanol_ua.name],
+            forcefield_selection={
+                two_propanol_ua.name: get_mosdef_gomc_fn(
+                    "gmso_two_propanol_OPLS_dihedrals_half_times_1_ua.xml"
+                ),
+            },
+            bead_to_atom_name_dict={"_CH3": "C", "_CH2": "C", "_HC": "C"},
+            atom_type_naming_style="general",
+        )
+        charmm.write_inp()
+
+        with open("gmso_OPLS_dihedral_gomc.inp", "r") as fp:
             dihedrals_read = False
             out_gomc = fp.readlines()
             for i, line in enumerate(out_gomc):
@@ -6664,6 +6780,395 @@ class TestCharmmWriterData(BaseTest):
                     pass
 
         assert dihedrals_read
+
+    # test the gmso OPLS dihderal input with 0.5 times 2 OPLS torsion values
+    def test_save_gmso_OPLS_dihedral_half_times_2_gomc_ff(self, two_propanol_ua):
+        box_0 = mb.fill_box(
+            compound=[two_propanol_ua], n_compounds=[1], box=[4, 4, 4]
+        )
+
+        charmm = Charmm(
+            box_0,
+            "gmso_OPLS_dihedral_gomc",
+            ff_filename="gmso_OPLS_dihedral_gomc",
+            residues=[two_propanol_ua.name],
+            forcefield_selection={
+                two_propanol_ua.name: get_mosdef_gomc_fn(
+                    "gmso_two_propanol_OPLS_dihedrals_half_times_2_ua.xml"
+                ),
+            },
+            bead_to_atom_name_dict={"_CH3": "C", "_CH2": "C", "_HC": "C"},
+            atom_type_naming_style="general",
+        )
+        charmm.write_inp()
+
+        with open("gmso_OPLS_dihedral_gomc.inp", "r") as fp:
+            dihedrals_read = False
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if (
+                        "! type_1" in line
+                        and "type_2" in line
+                        and "type_3" in line
+                        and "type_4" in line
+                        and "Kchi" in line
+                        and "n" in line
+                        and "delta" in line
+                        and "extended_type_1" in line
+                        and "extended_type_2" in line
+                        and "extended_type_3" in line
+                        and "extended_type_4" in line
+                ):
+                    dihedrals_read = True
+                    dihedral_types = [
+                        ["CH3", "CH", "O", "H", "-0.78427", "1", "180.0"],
+                        ["CH3", "CH", "O", "H", "-0.125036", "2", "0.0"],
+                        ["CH3", "CH", "O", "H", "0.69123", "3", "180.0"],
+                    ]
+                    for j in range(0, len(dihedral_types)):
+                        assert (
+                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
+                        )
+                        assert (
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:7]
+                                == dihedral_types[j]
+                        )
+
+                else:
+                    pass
+
+        assert dihedrals_read
+
+    # test the gmso periodic dihderal input add k (bonds, angles, dihedrals times 1/2)
+    def test_save_gmso_periodic_dihedral_gomc_ff_all_ks_times_half(self, two_propanol_ua):
+        box_0 = mb.fill_box(
+            compound=[two_propanol_ua], n_compounds=[1], box=[4, 4, 4]
+        )
+
+        charmm = Charmm(
+            box_0,
+            "gmso_periodic_dihedral_gomc",
+            ff_filename="gmso_periodic_dihedral_gomc",
+            residues=[two_propanol_ua.name],
+            forcefield_selection={
+                two_propanol_ua.name: get_mosdef_gomc_fn(
+                    "gmso_two_propanol_periodic_dihedrals_ua_all_bond_angles_dihedrals_k_times_half.xml"
+                ),
+            },
+            bead_to_atom_name_dict={"_CH3": "C", "_CH2": "C", "_HC": "C"},
+            atom_type_naming_style="general",
+        )
+        charmm.write_inp()
+
+        with open("gmso_periodic_dihedral_gomc.inp", "r") as fp:
+
+            masses_read = False
+            bonds_read = False
+            angles_read = False
+            dihedrals_read = False
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if (
+                        "! atom_types" in line
+                        and "mass" in line
+                        and "atomClass_ResidueName" in line
+                ):
+                    masses_read = True
+                    atom_types_1 = [
+                        ["*", "CH3", "15.035"],
+                        ["*", "CH", "13.019"],
+                        ["*", "O", "15.9994"],
+                        ["*", "H", "1.008"],
+                    ]
+                    atom_types_2 = [
+                        ["POL_CH3_sp3"],
+                        ["POL_CH_O"],
+                        ["POL_O"],
+                        ["POL_H"],
+                    ]
+
+                    for j in range(0, len(atom_types_1)):
+                        assert (
+                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 3
+                        )
+                        assert (
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:3]
+                                == atom_types_1[j]
+                        )
+                        assert (
+                                out_gomc[i + 1 + j].split()[4:5] == atom_types_2[j]
+                        )
+
+                elif (
+                        "! type_1" in line
+                        and "type_2" in line
+                        and "Kb" in line
+                        and "b0" in line
+                        and "extended_type_1" in line
+                        and "extended_type_2" in line
+                ):
+                    bonds_read = True
+                    bond_types = [
+                        ["CH3", "CH", "600.40153", "1.54"],
+                        ["CH", "O", "600.40153", "1.43"],
+                        ["O", "H", "600.40153", "0.945"],
+                    ]
+                    total_bonds_evaluated = []
+                    total_bonds_evaluated_reorg = []
+                    for j in range(0, len(bond_types)):
+                        assert (
+                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 4
+                        )
+
+                        if (
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:4]
+                                == bond_types[0]
+                                or bond_types[1]
+                                or bond_types[2]
+                        ):
+                            total_bonds_evaluated.append(
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:4]
+                            )
+                    for k in range(0, len(bond_types)):
+                        if bond_types[k] in total_bonds_evaluated:
+                            total_bonds_evaluated_reorg.append(bond_types[k])
+                    assert total_bonds_evaluated_reorg == bond_types
+
+                elif (
+                        "! type_1 " in line
+                        and "type_2" in line
+                        and "type_3" in line
+                        and "Ktheta" in line
+                        and "Theta0" in line
+                        and "extended_type_1" in line
+                        and "extended_type_2" in line
+                        and "extended_type_3" in line
+                ):
+                    angles_read = True
+                    angle_types = [
+                        ["CH3", "CH", "O", "50.077544", "109.469889"],
+                        ["CH3", "CH", "CH3", "62.10013", "112.000071"],
+                        ["CH", "O", "H", "55.045554", "108.499872"],
+                    ]
+                    total_angles_evaluated = []
+                    total_angles_evaluated_reorg = []
+                    for j in range(0, len(angle_types)):
+                        assert (
+                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 5
+                        )
+                        if (
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:5]
+                                == angle_types[0]
+                                or angle_types[1]
+                                or angle_types[2]
+                        ):
+                            total_angles_evaluated.append(
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:5]
+                            )
+                    for k in range(0, len(angle_types)):
+                        if angle_types[k] in total_angles_evaluated:
+                            total_angles_evaluated_reorg.append(angle_types[k])
+
+                    assert total_angles_evaluated_reorg == angle_types
+
+                elif (
+                        "! type_1" in line
+                        and "type_2" in line
+                        and "type_3" in line
+                        and "type_4" in line
+                        and "Kchi" in line
+                        and "n" in line
+                        and "delta" in line
+                        and "extended_type_1" in line
+                        and "extended_type_2" in line
+                        and "extended_type_3" in line
+                        and "extended_type_4" in line
+                ):
+                    dihedrals_read = True
+                    dihedral_types = [
+                        ["CH3", "CH", "O", "H", "-0.196067", "1", "180.0"],
+                        ["CH3", "CH", "O", "H", "-0.031259", "2", "0.0"],
+                        ["CH3", "CH", "O", "H", "0.172807", "3", "180.0"],
+                    ]
+                    for j in range(0, len(dihedral_types)):
+                        assert (
+                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
+                        )
+                        assert (
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:7]
+                                == dihedral_types[j]
+                        )
+
+        assert masses_read
+        assert bonds_read
+        assert angles_read
+        assert dihedrals_read
+
+    # test the gmso periodic dihderal input add k (bonds, angles, dihedrals times 1)
+    def test_save_gmso_periodic_dihedral_gomc_ff_all_ks_times_1(self, two_propanol_ua):
+        box_0 = mb.fill_box(
+            compound=[two_propanol_ua], n_compounds=[1], box=[4, 4, 4]
+        )
+
+        charmm = Charmm(
+            box_0,
+            "gmso_periodic_dihedral_gomc",
+            ff_filename="gmso_periodic_dihedral_gomc",
+            residues=[two_propanol_ua.name],
+            forcefield_selection={
+                two_propanol_ua.name: get_mosdef_gomc_fn(
+                    "gmso_two_propanol_periodic_dihedrals_ua_all_bond_angles_dihedrals_k_times_1.xml"
+                ),
+            },
+            bead_to_atom_name_dict={"_CH3": "C", "_CH2": "C", "_HC": "C"},
+            atom_type_naming_style="general",
+        )
+        charmm.write_inp()
+
+        with open("gmso_periodic_dihedral_gomc.inp", "r") as fp:
+
+            masses_read = False
+            bonds_read = False
+            angles_read = False
+            dihedrals_read = False
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if (
+                        "! atom_types" in line
+                        and "mass" in line
+                        and "atomClass_ResidueName" in line
+                ):
+                    masses_read = True
+                    atom_types_1 = [
+                        ["*", "CH3", "15.035"],
+                        ["*", "CH", "13.019"],
+                        ["*", "O", "15.9994"],
+                        ["*", "H", "1.008"],
+                    ]
+                    atom_types_2 = [
+                        ["POL_CH3_sp3"],
+                        ["POL_CH_O"],
+                        ["POL_O"],
+                        ["POL_H"],
+                    ]
+
+                    for j in range(0, len(atom_types_1)):
+                        assert (
+                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 3
+                        )
+                        assert (
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:3]
+                                == atom_types_1[j]
+                        )
+                        assert (
+                                out_gomc[i + 1 + j].split()[4:5] == atom_types_2[j]
+                        )
+
+                elif (
+                        "! type_1" in line
+                        and "type_2" in line
+                        and "Kb" in line
+                        and "b0" in line
+                        and "extended_type_1" in line
+                        and "extended_type_2" in line
+                ):
+                    bonds_read = True
+                    bond_types = [
+                        ["CH3", "CH", "1200.803059", "1.54"],
+                        ["CH", "O", "1200.803059", "1.43"],
+                        ["O", "H", "1200.803059", "0.945"],
+                    ]
+                    total_bonds_evaluated = []
+                    total_bonds_evaluated_reorg = []
+                    for j in range(0, len(bond_types)):
+                        assert (
+                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 4
+                        )
+
+                        if (
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:4]
+                                == bond_types[0]
+                                or bond_types[1]
+                                or bond_types[2]
+                        ):
+                            total_bonds_evaluated.append(
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:4]
+                            )
+                    for k in range(0, len(bond_types)):
+                        if bond_types[k] in total_bonds_evaluated:
+                            total_bonds_evaluated_reorg.append(bond_types[k])
+                    assert total_bonds_evaluated_reorg == bond_types
+
+                elif (
+                        "! type_1 " in line
+                        and "type_2" in line
+                        and "type_3" in line
+                        and "Ktheta" in line
+                        and "Theta0" in line
+                        and "extended_type_1" in line
+                        and "extended_type_2" in line
+                        and "extended_type_3" in line
+                ):
+                    angles_read = True
+                    angle_types = [
+                        ["CH3", "CH", "O", "100.155088", "109.469889"],
+                        ["CH3", "CH", "CH3", "124.200261", "112.000071"],
+                        ["CH", "O", "H", "110.091109", "108.499872"],
+                    ]
+                    total_angles_evaluated = []
+                    total_angles_evaluated_reorg = []
+                    for j in range(0, len(angle_types)):
+                        assert (
+                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 5
+                        )
+                        if (
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:5]
+                                == angle_types[0]
+                                or angle_types[1]
+                                or angle_types[2]
+                        ):
+                            total_angles_evaluated.append(
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:5]
+                            )
+                    for k in range(0, len(angle_types)):
+                        if angle_types[k] in total_angles_evaluated:
+                            total_angles_evaluated_reorg.append(angle_types[k])
+
+                    assert total_angles_evaluated_reorg == angle_types
+
+                elif (
+                        "! type_1" in line
+                        and "type_2" in line
+                        and "type_3" in line
+                        and "type_4" in line
+                        and "Kchi" in line
+                        and "n" in line
+                        and "delta" in line
+                        and "extended_type_1" in line
+                        and "extended_type_2" in line
+                        and "extended_type_3" in line
+                        and "extended_type_4" in line
+                ):
+                    dihedrals_read = True
+                    dihedral_types = [
+                        ["CH3", "CH", "O", "H", "-0.392135", "1", "180.0"],
+                        ["CH3", "CH", "O", "H", "-0.062518", "2", "0.0"],
+                        ["CH3", "CH", "O", "H", "0.345615", "3", "180.0"],
+                    ]
+                    for j in range(0, len(dihedral_types)):
+                        assert (
+                                len(out_gomc[i + 1 + j].split("!")[0].split()) == 7
+                        )
+                        assert (
+                                out_gomc[i + 1 + j].split("!")[0].split()[0:7]
+                                == dihedral_types[j]
+                        )
+
+        assert masses_read
+        assert bonds_read
+        assert angles_read
+        assert dihedrals_read
+
 
     # test the gmso periodic wildcard dihderal input
     def test_save_gmso_periodic_wildcard_dihedral_gomc_ff(
@@ -7503,10 +8008,10 @@ class TestCharmmWriterData(BaseTest):
                 ff_filename="test_atom_typ_style_general_passes_tests",
                 forcefield_selection={
                     two_propanol_ua.name: get_mosdef_gomc_fn(
-                        "gmso_two_propanol_periodic_dihedrals_ua.xml"
+                        "gmso_two_propanol_periodic_dihedrals_ua_all_bond_angles_dihedrals_k_times_half.xml"
                     ),
                     alt_two_propanol_ua.name: get_mosdef_gomc_fn(
-                        "gmso_two_propanol_periodic_dihedrals_ua.xml"
+                        "gmso_two_propanol_periodic_dihedrals_ua_all_bond_angles_dihedrals_k_times_half.xml"
                     ),
                 },
                 residues=[two_propanol_ua.name, alt_two_propanol_ua.name],

--- a/mosdef_gomc/utils/files/gmso_two_propanol_OPLS_dihedrals_0_5_times_1_ua.xml
+++ b/mosdef_gomc/utils/files/gmso_two_propanol_OPLS_dihedrals_0_5_times_1_ua.xml
@@ -75,30 +75,19 @@
       </Parameters>
     </AngleType>
   </AngleTypes>
-  <DihedralTypes expression="k * (1 + cos(n * phi - phi_eq))">
-    <ParametersUnitDef parameter="k" unit="kJ/mol"/>
-    <ParametersUnitDef parameter="n" unit="dimensionless"/>
-    <ParametersUnitDef parameter="phi_eq" unit="radian"/>
+  <DihedralTypes expression="1* (0.5 * k0 + 0.5  * k1 * (1 + cos(phi)) + 0.5  * k2 * (1 - cos(2*phi)) + 0.5  * k3 * (1 + cos(3*phi)) + 0.5 * k4 * (1 - cos(4*phi)))">
+    <ParametersUnitDef parameter="k0" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k1" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k2" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k3" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k4" unit="kJ/mol"/>
     <DihedralType name="DihedralType_RB_Proper_CH3_CH_O_H" class1="CH3" class2="CH" class3="O" class4="H">
       <Parameters>
-        <Parameter name="n">
-          <Value>0</Value>
-          <Value>1</Value>
-          <Value>2</Value>
-          <Value>3</Value>
-        </Parameter>
-        <Parameter name="k">
-          <Value>2.70802</Value>
-          <Value>-1.6406925</Value>
-          <Value>-0.261575</Value>
-          <Value>1.4460525</Value>
-        </Parameter>
-        <Parameter name="phi_eq">
-          <Value>1.570796326794897</Value>
-          <Value>3.141592653589793</Value>
-          <Value>0.0</Value>
-          <Value>3.141592653589793</Value>
-        </Parameter>
+        <Parameter name="k0" value="3.59118"/>
+        <Parameter name="k1" value="3.281385"/>
+        <Parameter name="k2" value="0.52315"/>
+        <Parameter name="k3" value="-2.892105"/>
+        <Parameter name="k4" value="0.0"/>
       </Parameters>
     </DihedralType>
   </DihedralTypes>

--- a/mosdef_gomc/utils/files/gmso_two_propanol_OPLS_dihedrals_0_5_times_2_ua.xml
+++ b/mosdef_gomc/utils/files/gmso_two_propanol_OPLS_dihedrals_0_5_times_2_ua.xml
@@ -1,0 +1,94 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ForceField name="trappe-ua two-propanol-ua" version="0.0.1">
+  <FFMetaData electrostatics14Scale="0.0" nonBonded14Scale="0.0" combiningRule="lorentz">
+    <Units energy="kJ/mol" mass="amu" charge="elementary_charge" distance="nm"/>
+  </FFMetaData>
+  <AtomTypes expression="4 * epsilon * ((sigma/r)**12 - (sigma/r)**6)">
+    <ParametersUnitDef parameter="sigma" unit="nm"/>
+    <ParametersUnitDef parameter="epsilon" unit="kJ/mol"/>
+    <AtomType name="CH3_sp3" atomclass="CH3" element="_CH3" charge="0.0" mass="15.03500" definition="[_CH3;X1][_CH3,_HC]" description="Alkane CH3, united atom" doi="10.1021/jp972543+" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.814817"/>
+        <Parameter name="sigma" value="0.375"/>
+      </Parameters>
+    </AtomType>
+    <AtomType name="CH_O" atomclass="CH" element="_HC" charge="0.265" mass="13.01900" definition="[_HC;X3]([_CH3,_HC])([_CH3,_HC])OH" description="CH, united atom, attached to hydroxyl" doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.0831445"/>
+        <Parameter name="sigma" value="0.433"/>
+      </Parameters>
+    </AtomType>
+    <AtomType name="O" atomclass="O" element="O" charge="-0.700" mass="15.99940" definition="OH"  description="Oxygen in hydroxyl"  doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.773245"/>
+        <Parameter name="sigma" value="0.302"/>
+      </Parameters>
+    </AtomType>
+  <AtomType name="H" atomclass="H" element="H" charge="0.435" mass="1.00800" definition="HO" description="Hydrogen in hydroxyl" doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.0"/>
+        <Parameter name="sigma" value="1.0"/>
+      </Parameters>
+    </AtomType>
+  </AtomTypes>
+  <BondTypes expression="k/2 * (r-r_eq)**2">
+    <ParametersUnitDef parameter="r_eq" unit="nm"/>
+    <ParametersUnitDef parameter="k" unit="kJ/mol/nm**2"/>
+    <BondType name="BondType_Harmonic_CH3_CH" class1="CH3" class2="CH">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.1540"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_CH_O" class1="CH" class2="O">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.1430"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_O_H" class1="O" class2="H">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.0945"/>
+      </Parameters>
+    </BondType>
+  </BondTypes>
+  <AngleTypes expression="k/2 * (theta - theta_eq)**2">
+    <ParametersUnitDef parameter="theta_eq" unit="radian"/>
+    <ParametersUnitDef parameter="k" unit="kJ/mol/radian**2"/>
+    <AngleType name="AngleType_Harmonic_CH3_CH_CH3" class1="CH3" class2="CH" class3="CH3">
+      <Parameters>
+        <Parameter name="k" value="519.65389"/>
+        <Parameter name="theta_eq" value="1.95477"/>
+      </Parameters>
+    </AngleType>
+   <AngleType name="AngleType_Harmonic_CH3_CH_O" class1="CH3" class2="CH" class3="O">
+      <Parameters>
+        <Parameter name="k" value="419.04889"/>
+        <Parameter name="theta_eq" value="1.91061"/>
+      </Parameters>
+    </AngleType>
+    <AngleType name="AngleType_Harmonic_CH_O_H" class1="CH" class2="O" class3="H">
+      <Parameters>
+        <Parameter name="k" value="460.62120"/>
+        <Parameter name="theta_eq" value="1.89368"/>
+      </Parameters>
+    </AngleType>
+  </AngleTypes>
+  <DihedralTypes expression="2* (0.5 * k0 + 0.5  * k1 * (1 + cos(phi)) + 0.5  * k2 * (1 - cos(2*phi)) + 0.5  * k3 * (1 + cos(3*phi)) + 0.5 * k4 * (1 - cos(4*phi)))">
+    <ParametersUnitDef parameter="k0" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k1" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k2" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k3" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k4" unit="kJ/mol"/>
+    <DihedralType name="DihedralType_RB_Proper_CH3_CH_O_H" class1="CH3" class2="CH" class3="O" class4="H">
+      <Parameters>
+        <Parameter name="k0" value="3.59118"/>
+        <Parameter name="k1" value="3.281385"/>
+        <Parameter name="k2" value="0.52315"/>
+        <Parameter name="k3" value="-2.892105"/>
+        <Parameter name="k4" value="0.0"/>
+      </Parameters>
+    </DihedralType>
+  </DihedralTypes>
+</ForceField>

--- a/mosdef_gomc/utils/files/gmso_two_propanol_OPLS_dihedrals_half_times_1_ua.xml
+++ b/mosdef_gomc/utils/files/gmso_two_propanol_OPLS_dihedrals_half_times_1_ua.xml
@@ -1,0 +1,94 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ForceField name="trappe-ua two-propanol-ua" version="0.0.1">
+  <FFMetaData electrostatics14Scale="0.0" nonBonded14Scale="0.0" combiningRule="lorentz">
+    <Units energy="kJ/mol" mass="amu" charge="elementary_charge" distance="nm"/>
+  </FFMetaData>
+  <AtomTypes expression="4 * epsilon * ((sigma/r)**12 - (sigma/r)**6)">
+    <ParametersUnitDef parameter="sigma" unit="nm"/>
+    <ParametersUnitDef parameter="epsilon" unit="kJ/mol"/>
+    <AtomType name="CH3_sp3" atomclass="CH3" element="_CH3" charge="0.0" mass="15.03500" definition="[_CH3;X1][_CH3,_HC]" description="Alkane CH3, united atom" doi="10.1021/jp972543+" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.814817"/>
+        <Parameter name="sigma" value="0.375"/>
+      </Parameters>
+    </AtomType>
+    <AtomType name="CH_O" atomclass="CH" element="_HC" charge="0.265" mass="13.01900" definition="[_HC;X3]([_CH3,_HC])([_CH3,_HC])OH" description="CH, united atom, attached to hydroxyl" doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.0831445"/>
+        <Parameter name="sigma" value="0.433"/>
+      </Parameters>
+    </AtomType>
+    <AtomType name="O" atomclass="O" element="O" charge="-0.700" mass="15.99940" definition="OH"  description="Oxygen in hydroxyl"  doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.773245"/>
+        <Parameter name="sigma" value="0.302"/>
+      </Parameters>
+    </AtomType>
+  <AtomType name="H" atomclass="H" element="H" charge="0.435" mass="1.00800" definition="HO" description="Hydrogen in hydroxyl" doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.0"/>
+        <Parameter name="sigma" value="1.0"/>
+      </Parameters>
+    </AtomType>
+  </AtomTypes>
+  <BondTypes expression="k/2 * (r-r_eq)**2">
+    <ParametersUnitDef parameter="r_eq" unit="nm"/>
+    <ParametersUnitDef parameter="k" unit="kJ/mol/nm**2"/>
+    <BondType name="BondType_Harmonic_CH3_CH" class1="CH3" class2="CH">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.1540"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_CH_O" class1="CH" class2="O">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.1430"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_O_H" class1="O" class2="H">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.0945"/>
+      </Parameters>
+    </BondType>
+  </BondTypes>
+  <AngleTypes expression="k/2 * (theta - theta_eq)**2">
+    <ParametersUnitDef parameter="theta_eq" unit="radian"/>
+    <ParametersUnitDef parameter="k" unit="kJ/mol/radian**2"/>
+    <AngleType name="AngleType_Harmonic_CH3_CH_CH3" class1="CH3" class2="CH" class3="CH3">
+      <Parameters>
+        <Parameter name="k" value="519.65389"/>
+        <Parameter name="theta_eq" value="1.95477"/>
+      </Parameters>
+    </AngleType>
+   <AngleType name="AngleType_Harmonic_CH3_CH_O" class1="CH3" class2="CH" class3="O">
+      <Parameters>
+        <Parameter name="k" value="419.04889"/>
+        <Parameter name="theta_eq" value="1.91061"/>
+      </Parameters>
+    </AngleType>
+    <AngleType name="AngleType_Harmonic_CH_O_H" class1="CH" class2="O" class3="H">
+      <Parameters>
+        <Parameter name="k" value="460.62120"/>
+        <Parameter name="theta_eq" value="1.89368"/>
+      </Parameters>
+    </AngleType>
+  </AngleTypes>
+  <DihedralTypes expression="1 * (1/2 * k0 + 1/2 * k1 * (1 + cos(phi)) + 1/2  * k2 * (1 - cos(2*phi)) + 1/2  * k3 * (1 + cos(3*phi)) + 1/2  * k4 * (1 - cos(4*phi)))">
+    <ParametersUnitDef parameter="k0" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k1" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k2" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k3" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k4" unit="kJ/mol"/>
+    <DihedralType name="DihedralType_RB_Proper_CH3_CH_O_H" class1="CH3" class2="CH" class3="O" class4="H">
+      <Parameters>
+        <Parameter name="k0" value="3.59118"/>
+        <Parameter name="k1" value="3.281385"/>
+        <Parameter name="k2" value="0.52315"/>
+        <Parameter name="k3" value="-2.892105"/>
+        <Parameter name="k4" value="0.0"/>
+      </Parameters>
+    </DihedralType>
+  </DihedralTypes>
+</ForceField>

--- a/mosdef_gomc/utils/files/gmso_two_propanol_OPLS_dihedrals_half_times_2_ua.xml
+++ b/mosdef_gomc/utils/files/gmso_two_propanol_OPLS_dihedrals_half_times_2_ua.xml
@@ -1,0 +1,94 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ForceField name="trappe-ua two-propanol-ua" version="0.0.1">
+  <FFMetaData electrostatics14Scale="0.0" nonBonded14Scale="0.0" combiningRule="lorentz">
+    <Units energy="kJ/mol" mass="amu" charge="elementary_charge" distance="nm"/>
+  </FFMetaData>
+  <AtomTypes expression="4 * epsilon * ((sigma/r)**12 - (sigma/r)**6)">
+    <ParametersUnitDef parameter="sigma" unit="nm"/>
+    <ParametersUnitDef parameter="epsilon" unit="kJ/mol"/>
+    <AtomType name="CH3_sp3" atomclass="CH3" element="_CH3" charge="0.0" mass="15.03500" definition="[_CH3;X1][_CH3,_HC]" description="Alkane CH3, united atom" doi="10.1021/jp972543+" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.814817"/>
+        <Parameter name="sigma" value="0.375"/>
+      </Parameters>
+    </AtomType>
+    <AtomType name="CH_O" atomclass="CH" element="_HC" charge="0.265" mass="13.01900" definition="[_HC;X3]([_CH3,_HC])([_CH3,_HC])OH" description="CH, united atom, attached to hydroxyl" doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.0831445"/>
+        <Parameter name="sigma" value="0.433"/>
+      </Parameters>
+    </AtomType>
+    <AtomType name="O" atomclass="O" element="O" charge="-0.700" mass="15.99940" definition="OH"  description="Oxygen in hydroxyl"  doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.773245"/>
+        <Parameter name="sigma" value="0.302"/>
+      </Parameters>
+    </AtomType>
+  <AtomType name="H" atomclass="H" element="H" charge="0.435" mass="1.00800" definition="HO" description="Hydrogen in hydroxyl" doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.0"/>
+        <Parameter name="sigma" value="1.0"/>
+      </Parameters>
+    </AtomType>
+  </AtomTypes>
+  <BondTypes expression="k/2 * (r-r_eq)**2">
+    <ParametersUnitDef parameter="r_eq" unit="nm"/>
+    <ParametersUnitDef parameter="k" unit="kJ/mol/nm**2"/>
+    <BondType name="BondType_Harmonic_CH3_CH" class1="CH3" class2="CH">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.1540"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_CH_O" class1="CH" class2="O">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.1430"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_O_H" class1="O" class2="H">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.0945"/>
+      </Parameters>
+    </BondType>
+  </BondTypes>
+  <AngleTypes expression="k/2 * (theta - theta_eq)**2">
+    <ParametersUnitDef parameter="theta_eq" unit="radian"/>
+    <ParametersUnitDef parameter="k" unit="kJ/mol/radian**2"/>
+    <AngleType name="AngleType_Harmonic_CH3_CH_CH3" class1="CH3" class2="CH" class3="CH3">
+      <Parameters>
+        <Parameter name="k" value="519.65389"/>
+        <Parameter name="theta_eq" value="1.95477"/>
+      </Parameters>
+    </AngleType>
+   <AngleType name="AngleType_Harmonic_CH3_CH_O" class1="CH3" class2="CH" class3="O">
+      <Parameters>
+        <Parameter name="k" value="419.04889"/>
+        <Parameter name="theta_eq" value="1.91061"/>
+      </Parameters>
+    </AngleType>
+    <AngleType name="AngleType_Harmonic_CH_O_H" class1="CH" class2="O" class3="H">
+      <Parameters>
+        <Parameter name="k" value="460.62120"/>
+        <Parameter name="theta_eq" value="1.89368"/>
+      </Parameters>
+    </AngleType>
+  </AngleTypes>
+  <DihedralTypes expression="2 * (1/2 * k0 + 1/2 * k1 * (1 + cos(phi)) + 1/2  * k2 * (1 - cos(2*phi)) + 1/2  * k3 * (1 + cos(3*phi)) + 1/2  * k4 * (1 - cos(4*phi)))">
+    <ParametersUnitDef parameter="k0" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k1" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k2" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k3" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="k4" unit="kJ/mol"/>
+    <DihedralType name="DihedralType_RB_Proper_CH3_CH_O_H" class1="CH3" class2="CH" class3="O" class4="H">
+      <Parameters>
+        <Parameter name="k0" value="3.59118"/>
+        <Parameter name="k1" value="3.281385"/>
+        <Parameter name="k2" value="0.52315"/>
+        <Parameter name="k3" value="-2.892105"/>
+        <Parameter name="k4" value="0.0"/>
+      </Parameters>
+    </DihedralType>
+  </DihedralTypes>
+</ForceField>

--- a/mosdef_gomc/utils/files/gmso_two_propanol_RB_dihedrals_times_1_ua.xml
+++ b/mosdef_gomc/utils/files/gmso_two_propanol_RB_dihedrals_times_1_ua.xml
@@ -1,0 +1,96 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ForceField name="trappe-ua two-propanol-ua" version="0.0.1">
+  <FFMetaData electrostatics14Scale="0.0" nonBonded14Scale="0.0" combiningRule="lorentz">
+    <Units energy="kJ/mol" mass="amu" charge="elementary_charge" distance="nm"/>
+  </FFMetaData>
+  <AtomTypes expression="4 * epsilon * ((sigma/r)**12 - (sigma/r)**6)">
+    <ParametersUnitDef parameter="sigma" unit="nm"/>
+    <ParametersUnitDef parameter="epsilon" unit="kJ/mol"/>
+    <AtomType name="CH3_sp3" atomclass="CH3" element="_CH3" charge="0.0" mass="15.03500" definition="[_CH3;X1][_CH3,_HC]" description="Alkane CH3, united atom" doi="10.1021/jp972543+" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.814817"/>
+        <Parameter name="sigma" value="0.375"/>
+      </Parameters>
+    </AtomType>
+    <AtomType name="CH_O" atomclass="CH" element="_HC" charge="0.265" mass="13.01900" definition="[_HC;X3]([_CH3,_HC])([_CH3,_HC])OH" description="CH, united atom, attached to hydroxyl" doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.0831445"/>
+        <Parameter name="sigma" value="0.433"/>
+      </Parameters>
+    </AtomType>
+    <AtomType name="O" atomclass="O" element="O" charge="-0.700" mass="15.99940" definition="OH"  description="Oxygen in hydroxyl"  doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.773245"/>
+        <Parameter name="sigma" value="0.302"/>
+      </Parameters>
+    </AtomType>
+  <AtomType name="H" atomclass="H" element="H" charge="0.435" mass="1.00800" definition="HO" description="Hydrogen in hydroxyl" doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.0"/>
+        <Parameter name="sigma" value="1.0"/>
+      </Parameters>
+    </AtomType>
+  </AtomTypes>
+  <BondTypes expression="k/2 * (r-r_eq)**2">
+    <ParametersUnitDef parameter="r_eq" unit="nm"/>
+    <ParametersUnitDef parameter="k" unit="kJ/mol/nm**2"/>
+    <BondType name="BondType_Harmonic_CH3_CH" class1="CH3" class2="CH">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.1540"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_CH_O" class1="CH" class2="O">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.1430"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_O_H" class1="O" class2="H">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.0945"/>
+      </Parameters>
+    </BondType>
+  </BondTypes>
+  <AngleTypes expression="k/2 * (theta - theta_eq)**2">
+    <ParametersUnitDef parameter="theta_eq" unit="radian"/>
+    <ParametersUnitDef parameter="k" unit="kJ/mol/radian**2"/>
+    <AngleType name="AngleType_Harmonic_CH3_CH_CH3" class1="CH3" class2="CH" class3="CH3">
+      <Parameters>
+        <Parameter name="k" value="519.65389"/>
+        <Parameter name="theta_eq" value="1.95477"/>
+      </Parameters>
+    </AngleType>
+   <AngleType name="AngleType_Harmonic_CH3_CH_O" class1="CH3" class2="CH" class3="O">
+      <Parameters>
+        <Parameter name="k" value="419.04889"/>
+        <Parameter name="theta_eq" value="1.91061"/>
+      </Parameters>
+    </AngleType>
+    <AngleType name="AngleType_Harmonic_CH_O_H" class1="CH" class2="O" class3="H">
+      <Parameters>
+        <Parameter name="k" value="460.62120"/>
+        <Parameter name="theta_eq" value="1.89368"/>
+      </Parameters>
+    </AngleType>
+  </AngleTypes>
+  <DihedralTypes expression="c0 + c1 * cos(phi)**1 + c2 * cos(phi)**2 + c3 * cos(phi)**3 + c4 * cos(phi)**4 + c5 * cos(phi)**5">
+    <ParametersUnitDef parameter="c5" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="c4" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="c3" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="c2" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="c1" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="c0" unit="kJ/mol"/>
+    <DihedralType name="DihedralType_RB_Proper_CH3_CH_O_H" class1="CH3" class2="CH" class3="O" class4="H">
+      <Parameters>
+        <Parameter name="c0" value="2.51338"/>
+        <Parameter name="c1" value="-5.97885"/>
+        <Parameter name="c2" value="-0.52315"/>
+        <Parameter name="c3" value="5.78421"/>
+        <Parameter name="c4" value="0.0"/>
+        <Parameter name="c5" value="0.0"/>
+      </Parameters>
+    </DihedralType>
+  </DihedralTypes>
+</ForceField>

--- a/mosdef_gomc/utils/files/gmso_two_propanol_RB_dihedrals_times_2_ua.xml
+++ b/mosdef_gomc/utils/files/gmso_two_propanol_RB_dihedrals_times_2_ua.xml
@@ -1,0 +1,96 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ForceField name="trappe-ua two-propanol-ua" version="0.0.1">
+  <FFMetaData electrostatics14Scale="0.0" nonBonded14Scale="0.0" combiningRule="lorentz">
+    <Units energy="kJ/mol" mass="amu" charge="elementary_charge" distance="nm"/>
+  </FFMetaData>
+  <AtomTypes expression="4 * epsilon * ((sigma/r)**12 - (sigma/r)**6)">
+    <ParametersUnitDef parameter="sigma" unit="nm"/>
+    <ParametersUnitDef parameter="epsilon" unit="kJ/mol"/>
+    <AtomType name="CH3_sp3" atomclass="CH3" element="_CH3" charge="0.0" mass="15.03500" definition="[_CH3;X1][_CH3,_HC]" description="Alkane CH3, united atom" doi="10.1021/jp972543+" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.814817"/>
+        <Parameter name="sigma" value="0.375"/>
+      </Parameters>
+    </AtomType>
+    <AtomType name="CH_O" atomclass="CH" element="_HC" charge="0.265" mass="13.01900" definition="[_HC;X3]([_CH3,_HC])([_CH3,_HC])OH" description="CH, united atom, attached to hydroxyl" doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.0831445"/>
+        <Parameter name="sigma" value="0.433"/>
+      </Parameters>
+    </AtomType>
+    <AtomType name="O" atomclass="O" element="O" charge="-0.700" mass="15.99940" definition="OH"  description="Oxygen in hydroxyl"  doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.773245"/>
+        <Parameter name="sigma" value="0.302"/>
+      </Parameters>
+    </AtomType>
+  <AtomType name="H" atomclass="H" element="H" charge="0.435" mass="1.00800" definition="HO" description="Hydrogen in hydroxyl" doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.0"/>
+        <Parameter name="sigma" value="1.0"/>
+      </Parameters>
+    </AtomType>
+  </AtomTypes>
+  <BondTypes expression="k/2 * (r-r_eq)**2">
+    <ParametersUnitDef parameter="r_eq" unit="nm"/>
+    <ParametersUnitDef parameter="k" unit="kJ/mol/nm**2"/>
+    <BondType name="BondType_Harmonic_CH3_CH" class1="CH3" class2="CH">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.1540"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_CH_O" class1="CH" class2="O">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.1430"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_O_H" class1="O" class2="H">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.0945"/>
+      </Parameters>
+    </BondType>
+  </BondTypes>
+  <AngleTypes expression="k/2 * (theta - theta_eq)**2">
+    <ParametersUnitDef parameter="theta_eq" unit="radian"/>
+    <ParametersUnitDef parameter="k" unit="kJ/mol/radian**2"/>
+    <AngleType name="AngleType_Harmonic_CH3_CH_CH3" class1="CH3" class2="CH" class3="CH3">
+      <Parameters>
+        <Parameter name="k" value="519.65389"/>
+        <Parameter name="theta_eq" value="1.95477"/>
+      </Parameters>
+    </AngleType>
+   <AngleType name="AngleType_Harmonic_CH3_CH_O" class1="CH3" class2="CH" class3="O">
+      <Parameters>
+        <Parameter name="k" value="419.04889"/>
+        <Parameter name="theta_eq" value="1.91061"/>
+      </Parameters>
+    </AngleType>
+    <AngleType name="AngleType_Harmonic_CH_O_H" class1="CH" class2="O" class3="H">
+      <Parameters>
+        <Parameter name="k" value="460.62120"/>
+        <Parameter name="theta_eq" value="1.89368"/>
+      </Parameters>
+    </AngleType>
+  </AngleTypes>
+  <DihedralTypes expression="2 * (c0 + c1 * cos(phi)**1 + c2 * cos(phi)**2 + c3 * cos(phi)**3 + c4 * cos(phi)**4 + c5 * cos(phi)**5)">
+    <ParametersUnitDef parameter="c5" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="c4" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="c3" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="c2" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="c1" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="c0" unit="kJ/mol"/>
+    <DihedralType name="DihedralType_RB_Proper_CH3_CH_O_H" class1="CH3" class2="CH" class3="O" class4="H">
+      <Parameters>
+        <Parameter name="c0" value="2.51338"/>
+        <Parameter name="c1" value="-5.97885"/>
+        <Parameter name="c2" value="-0.52315"/>
+        <Parameter name="c3" value="5.78421"/>
+        <Parameter name="c4" value="0.0"/>
+        <Parameter name="c5" value="0.0"/>
+      </Parameters>
+    </DihedralType>
+  </DihedralTypes>
+</ForceField>

--- a/mosdef_gomc/utils/files/gmso_two_propanol_periodic_dihedrals_ua_all_bond_angles_dihedrals_k_times_1.xml
+++ b/mosdef_gomc/utils/files/gmso_two_propanol_periodic_dihedrals_ua_all_bond_angles_dihedrals_k_times_1.xml
@@ -31,7 +31,7 @@
       </Parameters>
     </AtomType>
   </AtomTypes>
-  <BondTypes expression="k/2 * (r-r_eq)**2">
+  <BondTypes expression="k * (r-r_eq)**2">
     <ParametersUnitDef parameter="r_eq" unit="nm"/>
     <ParametersUnitDef parameter="k" unit="kJ/mol/nm**2"/>
     <BondType name="BondType_Harmonic_CH3_CH" class1="CH3" class2="CH">
@@ -53,7 +53,7 @@
       </Parameters>
     </BondType>
   </BondTypes>
-  <AngleTypes expression="k/2 * (theta - theta_eq)**2">
+  <AngleTypes expression="k * (theta - theta_eq)**2">
     <ParametersUnitDef parameter="theta_eq" unit="radian"/>
     <ParametersUnitDef parameter="k" unit="kJ/mol/radian**2"/>
     <AngleType name="AngleType_Harmonic_CH3_CH_CH3" class1="CH3" class2="CH" class3="CH3">
@@ -75,19 +75,30 @@
       </Parameters>
     </AngleType>
   </AngleTypes>
-  <DihedralTypes expression="0.5 * k0 + 0.5 * k1 * (1 + cos(phi)) + 0.5 * k2 * (1 - cos(2*phi)) + 0.5 * k3 * (1 + cos(3*phi)) + 0.5 * k4 * (1 - cos(4*phi))">
-    <ParametersUnitDef parameter="k0" unit="kJ/mol"/>
-    <ParametersUnitDef parameter="k1" unit="kJ/mol"/>
-    <ParametersUnitDef parameter="k2" unit="kJ/mol"/>
-    <ParametersUnitDef parameter="k3" unit="kJ/mol"/>
-    <ParametersUnitDef parameter="k4" unit="kJ/mol"/>
+  <DihedralTypes expression="k * (1 + cos(n * phi - phi_eq))">
+    <ParametersUnitDef parameter="k" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="n" unit="dimensionless"/>
+    <ParametersUnitDef parameter="phi_eq" unit="radian"/>
     <DihedralType name="DihedralType_RB_Proper_CH3_CH_O_H" class1="CH3" class2="CH" class3="O" class4="H">
       <Parameters>
-        <Parameter name="k0" value="3.59118"/>
-        <Parameter name="k1" value="3.281385"/>
-        <Parameter name="k2" value="0.52315"/>
-        <Parameter name="k3" value="-2.892105"/>
-        <Parameter name="k4" value="0.0"/>
+        <Parameter name="n">
+          <Value>0</Value>
+          <Value>1</Value>
+          <Value>2</Value>
+          <Value>3</Value>
+        </Parameter>
+        <Parameter name="k">
+          <Value>2.70802</Value>
+          <Value>-1.6406925</Value>
+          <Value>-0.261575</Value>
+          <Value>1.4460525</Value>
+        </Parameter>
+        <Parameter name="phi_eq">
+          <Value>1.570796326794897</Value>
+          <Value>3.141592653589793</Value>
+          <Value>0.0</Value>
+          <Value>3.141592653589793</Value>
+        </Parameter>
       </Parameters>
     </DihedralType>
   </DihedralTypes>

--- a/mosdef_gomc/utils/files/gmso_two_propanol_periodic_dihedrals_ua_all_bond_angles_dihedrals_k_times_half.xml
+++ b/mosdef_gomc/utils/files/gmso_two_propanol_periodic_dihedrals_ua_all_bond_angles_dihedrals_k_times_half.xml
@@ -1,0 +1,105 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ForceField name="trappe-ua two-propanol-ua" version="0.0.1">
+  <FFMetaData electrostatics14Scale="0.0" nonBonded14Scale="0.0" combiningRule="lorentz">
+    <Units energy="kJ/mol" mass="amu" charge="elementary_charge" distance="nm"/>
+  </FFMetaData>
+  <AtomTypes expression="4 * epsilon * ((sigma/r)**12 - (sigma/r)**6)">
+    <ParametersUnitDef parameter="sigma" unit="nm"/>
+    <ParametersUnitDef parameter="epsilon" unit="kJ/mol"/>
+    <AtomType name="CH3_sp3" atomclass="CH3" element="_CH3" charge="0.0" mass="15.03500" definition="[_CH3;X1][_CH3,_HC]" description="Alkane CH3, united atom" doi="10.1021/jp972543+" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.814817"/>
+        <Parameter name="sigma" value="0.375"/>
+      </Parameters>
+    </AtomType>
+    <AtomType name="CH_O" atomclass="CH" element="_HC" charge="0.265" mass="13.01900" definition="[_HC;X3]([_CH3,_HC])([_CH3,_HC])OH" description="CH, united atom, attached to hydroxyl" doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.0831445"/>
+        <Parameter name="sigma" value="0.433"/>
+      </Parameters>
+    </AtomType>
+    <AtomType name="O" atomclass="O" element="O" charge="-0.700" mass="15.99940" definition="OH"  description="Oxygen in hydroxyl"  doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.773245"/>
+        <Parameter name="sigma" value="0.302"/>
+      </Parameters>
+    </AtomType>
+  <AtomType name="H" atomclass="H" element="H" charge="0.435" mass="1.00800" definition="HO" description="Hydrogen in hydroxyl" doi="10.1021/jp003882x" overrides="">
+      <Parameters>
+        <Parameter name="epsilon" value="0.0"/>
+        <Parameter name="sigma" value="1.0"/>
+      </Parameters>
+    </AtomType>
+  </AtomTypes>
+  <BondTypes expression="k/2 * (r-r_eq)**2">
+    <ParametersUnitDef parameter="r_eq" unit="nm"/>
+    <ParametersUnitDef parameter="k" unit="kJ/mol/nm**2"/>
+    <BondType name="BondType_Harmonic_CH3_CH" class1="CH3" class2="CH">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.1540"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_CH_O" class1="CH" class2="O">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.1430"/>
+      </Parameters>
+    </BondType>
+    <BondType name="BondType_Harmonic_O_H" class1="O" class2="H">
+      <Parameters>
+        <Parameter name="k" value="502416.0"/>
+        <Parameter name="r_eq" value="0.0945"/>
+      </Parameters>
+    </BondType>
+  </BondTypes>
+  <AngleTypes expression="k/2 * (theta - theta_eq)**2">
+    <ParametersUnitDef parameter="theta_eq" unit="radian"/>
+    <ParametersUnitDef parameter="k" unit="kJ/mol/radian**2"/>
+    <AngleType name="AngleType_Harmonic_CH3_CH_CH3" class1="CH3" class2="CH" class3="CH3">
+      <Parameters>
+        <Parameter name="k" value="519.65389"/>
+        <Parameter name="theta_eq" value="1.95477"/>
+      </Parameters>
+    </AngleType>
+   <AngleType name="AngleType_Harmonic_CH3_CH_O" class1="CH3" class2="CH" class3="O">
+      <Parameters>
+        <Parameter name="k" value="419.04889"/>
+        <Parameter name="theta_eq" value="1.91061"/>
+      </Parameters>
+    </AngleType>
+    <AngleType name="AngleType_Harmonic_CH_O_H" class1="CH" class2="O" class3="H">
+      <Parameters>
+        <Parameter name="k" value="460.62120"/>
+        <Parameter name="theta_eq" value="1.89368"/>
+      </Parameters>
+    </AngleType>
+  </AngleTypes>
+  <DihedralTypes expression="k/2 * (1 + cos(n * phi - phi_eq))">
+    <ParametersUnitDef parameter="k" unit="kJ/mol"/>
+    <ParametersUnitDef parameter="n" unit="dimensionless"/>
+    <ParametersUnitDef parameter="phi_eq" unit="radian"/>
+    <DihedralType name="DihedralType_RB_Proper_CH3_CH_O_H" class1="CH3" class2="CH" class3="O" class4="H">
+      <Parameters>
+        <Parameter name="n">
+          <Value>0</Value>
+          <Value>1</Value>
+          <Value>2</Value>
+          <Value>3</Value>
+        </Parameter>
+        <Parameter name="k">
+          <Value>2.70802</Value>
+          <Value>-1.6406925</Value>
+          <Value>-0.261575</Value>
+          <Value>1.4460525</Value>
+        </Parameter>
+        <Parameter name="phi_eq">
+          <Value>1.570796326794897</Value>
+          <Value>3.141592653589793</Value>
+          <Value>0.0</Value>
+          <Value>3.141592653589793</Value>
+        </Parameter>
+      </Parameters>
+    </DihedralType>
+  </DihedralTypes>
+</ForceField>

--- a/mosdef_gomc/utils/gmso_equation_compare.py
+++ b/mosdef_gomc/utils/gmso_equation_compare.py
@@ -101,6 +101,7 @@ def evaluate_nonbonded_mie_format_with_scaler(new_mie_form, base_mie_form):
             ],
             [eqn_ratio],
         )
+
         form_scalar = float(list(values)[0][0])
         form_output = "Mie"
 
@@ -373,6 +374,7 @@ def evaluate_harmonic_bond_format_with_scaler(new_bond_form, base_bond_form):
 
         form_scalar = float(list(values)[0][0])
         form_output = "HarmonicBondPotential"
+
     except:
         form_scalar = None
         form_output = None


### PR DESCRIPTION
Added more checks for potential k-scalars are scaling properly if users enter the same form with only a scalar difference which includes:

- Bonds 
- Angles
- Dihedrals

Additionally, another form of the OPLS dihedral was added. Now both the 0.5 and 1/2 scalars are accepted in the OPLS dihedral form, as they are not the same in `sympy`, I assume because of how they solve it and the small rounding errors.  