### PR TITLE
adding the libarchive package needed by mamba

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ WORKDIR /mosdef_gomc
 # Create a group and user
 RUN addgroup -S anaconda && adduser -S anaconda -G anaconda
 
+# install the libarchive package needed by mamba
+RUN apk update && apk add libarchive
+
 RUN conda update conda -yq && \
   conda config --set always_yes yes --set changeps1 no && \
   . /opt/conda/etc/profile.d/conda.sh && \


### PR DESCRIPTION
Attempting to build the Docker image locally, the build command crashes at:
``mamba env create nomkl --file environment.yml``

It produces at error that ``libarchive`` cannot be found.

This PR updates the Dockerfile to install ``libarchive``.  With this change, the image successfully builds locally.  That said, I've not tested the actual deployment to Docker Hub through GitHub Actions because I don't have access to GOMC's credentials.