### PR TITLE
Add the Multi-particle move flags for GEMC-NVT and GEMC-NPT.

### DIFF
--- a/mosdef_gomc/formats/gmso_gomc_conf_writer.py
+++ b/mosdef_gomc/formats/gmso_gomc_conf_writer.py
@@ -2,9 +2,9 @@ import datetime
 import os
 from warnings import warn
 
+import numpy as np
 import unyt as u
 from unyt.dimensions import energy, length, pressure, temperature
-import numpy as np
 
 from mosdef_gomc.formats.gmso_charmm_writer import Charmm
 
@@ -727,7 +727,7 @@ def _get_all_possible_input_variables(description=False):
         "running each move, based on the calculated density of the GEMC boxes."
         "".format(_get_default_variables_dict()["MultiParticleLiquid"]),
         "MultiParticleGas": "bool, default=False (GEMC-only)                    : "
-        "Use the multi-particle moves (MultiParticleFreq and MultiParticleBrownianFreq) " 
+        "Use the multi-particle moves (MultiParticleFreq and MultiParticleBrownianFreq) "
         "in the gas/vapor phase. "
         "Note: GOMC determines the boxes are liquid or gas/vapor before "
         "running each move, based on the calculated density of the GEMC boxes."
@@ -4599,10 +4599,12 @@ class GOMCControl:
                 )
 
                 if (
-                        input_var_keys_list[var_iter] == key
-                        and key in possible_ensemble_variables_list
+                    input_var_keys_list[var_iter] == key
+                    and key in possible_ensemble_variables_list
                 ):
-                    self.MultiParticleBrownianFreq = self.input_variables_dict[key]
+                    self.MultiParticleBrownianFreq = self.input_variables_dict[
+                        key
+                    ]
 
             # MEMC moves freqencies
             key = "IntraMEMC-1Freq"
@@ -5982,7 +5984,10 @@ class GOMCControl:
             print("\t CrankShaftFreq = " + str(self.CrankShaftFreq))
             print("\t VolFreq = " + str(self.VolFreq))
             print("\t MultiParticleFreq = " + str(self.MultiParticleFreq))
-            print("\t MultiParticleBrownianFreq = " + str(self.MultiParticleBrownianFreq))
+            print(
+                "\t MultiParticleBrownianFreq = "
+                + str(self.MultiParticleBrownianFreq)
+            )
             print("\t IntraMEMC-1Freq = " + str(self.IntraMEMC_1Freq))
             print("\t MEMC-1Freq = " + str(self.MEMC_1Freq))
             print("\t IntraMEMC-2Freq = " + str(self.IntraMEMC_2Freq))
@@ -6007,7 +6012,9 @@ class GOMCControl:
             raise ValueError(print_error_message)
 
         # MultiParticleFreq and MultiParticleBrownianFreq cannot be used at the same time.
-        if not np.isclose(self.MultiParticleFreq, 0) and not np.isclose(self.MultiParticleBrownianFreq, 0):
+        if not np.isclose(self.MultiParticleFreq, 0) and not np.isclose(
+            self.MultiParticleBrownianFreq, 0
+        ):
             raise ValueError(
                 "ERROR: Both MultiParticle (MultiParticleFreq) and MultiParticleBrownian "
                 "(MultiParticleBrownianFreq) cannot be used at the same time."
@@ -6738,8 +6745,10 @@ class GOMCControl:
         data_control_file.write(" \n")
 
         # Mulit-particle move in Liquid and vapor/phases
-        if (not np.isclose(self.MultiParticleFreq, 0) or not np.isclose(self.MultiParticleBrownianFreq, 0))  \
-                and self.ensemble_type in [
+        if (
+            not np.isclose(self.MultiParticleFreq, 0)
+            or not np.isclose(self.MultiParticleBrownianFreq, 0)
+        ) and self.ensemble_type in [
             "GEMC_NPT",
             "GEMC_NVT",
         ]:

--- a/mosdef_gomc/formats/gmso_gomc_conf_writer.py
+++ b/mosdef_gomc/formats/gmso_gomc_conf_writer.py
@@ -1446,13 +1446,12 @@ def _get_possible_ensemble_input_variables(ensemble_type):
         ]
 
     elif ensemble_type in ["GEMC_NPT", "GEMC_NVT"]:
-        extra_sim_info_variables_list = \
-            [
-                "RcutCoulomb_box_1",
-                "FixVolBox0",
-                "MultiParticleLiquid",
-                "MultiParticleGas"
-            ]
+        extra_sim_info_variables_list = [
+            "RcutCoulomb_box_1",
+            "FixVolBox0",
+            "MultiParticleLiquid",
+            "MultiParticleGas",
+        ]
 
         free_energy_variables_list = []  # always empty for GEMC
 
@@ -3146,9 +3145,7 @@ class GOMCControl:
         self.MultiParticleLiquid = default_input_variables_dict[
             "MultiParticleLiquid"
         ]
-        self.MultiParticleGas = default_input_variables_dict[
-            "MultiParticleGas"
-        ]
+        self.MultiParticleGas = default_input_variables_dict["MultiParticleGas"]
 
         # MEMC data input
         self.ExchangeVolumeDim = default_input_variables_dict[
@@ -3499,8 +3496,8 @@ class GOMCControl:
                 )
 
                 if (
-                        input_var_keys_list[var_iter] == key
-                        and key in possible_ensemble_variables_list
+                    input_var_keys_list[var_iter] == key
+                    and key in possible_ensemble_variables_list
                 ):
                     self.MultiParticleLiquid = self.input_variables_dict[key]
 
@@ -3513,8 +3510,8 @@ class GOMCControl:
                 )
 
                 if (
-                        input_var_keys_list[var_iter] == key
-                        and key in possible_ensemble_variables_list
+                    input_var_keys_list[var_iter] == key
+                    and key in possible_ensemble_variables_list
                 ):
                     self.MultiParticleGas = self.input_variables_dict[key]
 
@@ -6682,7 +6679,9 @@ class GOMCControl:
             "GEMC_NVT",
         ]:
             data_control_file.write(
-                "{:25s} {}\n".format("MultiParticleLiquid", self.MultiParticleLiquid)
+                "{:25s} {}\n".format(
+                    "MultiParticleLiquid", self.MultiParticleLiquid
+                )
             )
             data_control_file.write(
                 "{:25s} {}\n".format("MultiParticleGas", self.MultiParticleGas)

--- a/mosdef_gomc/tests/test_gmso_gomc_conf_writer.py
+++ b/mosdef_gomc/tests/test_gmso_gomc_conf_writer.py
@@ -1728,7 +1728,9 @@ class TestGOMCControlFileWriter(BaseTest):
             "RcutCoulomb_box_1": True,
         }
 
-    def test_save_change_most_variable_NVT_mulitparticle(self, ethane_gomc, ethanol_gomc):
+    def test_save_change_most_variable_NVT_mulitparticle(
+        self, ethane_gomc, ethanol_gomc
+    ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
             n_compounds=[1, 1],
@@ -1810,7 +1812,9 @@ class TestGOMCControlFileWriter(BaseTest):
             },
         )
 
-        with open("test_save_change_most_variable_NVT_mulitparticle.conf", "r") as fp:
+        with open(
+            "test_save_change_most_variable_NVT_mulitparticle.conf", "r"
+        ) as fp:
             variables_read_dict = {
                 "Restart": False,
                 "ExpertMode": False,
@@ -2350,7 +2354,9 @@ class TestGOMCControlFileWriter(BaseTest):
             "OutSurfaceTension": True,
         }
 
-    def test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_default(self, ethane_gomc, ethanol_gomc):
+    def test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_default(
+        self, ethane_gomc, ethanol_gomc
+    ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
             n_compounds=[1, 1],
@@ -2384,7 +2390,10 @@ class TestGOMCControlFileWriter(BaseTest):
             },
         )
 
-        with open("test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_default.conf", "r") as fp:
+        with open(
+            "test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_default.conf",
+            "r",
+        ) as fp:
             variables_read_dict = {
                 "MultiParticleLiquid": False,
                 "MultiParticleGas": False,
@@ -2409,8 +2418,9 @@ class TestGOMCControlFileWriter(BaseTest):
             "MultiParticleGas": True,
         }
 
-
-    def test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_both_false(self, ethane_gomc, ethanol_gomc):
+    def test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_both_false(
+        self, ethane_gomc, ethanol_gomc
+    ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
             n_compounds=[1, 1],
@@ -2446,7 +2456,10 @@ class TestGOMCControlFileWriter(BaseTest):
             },
         )
 
-        with open("test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_both_false.conf", "r") as fp:
+        with open(
+            "test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_both_false.conf",
+            "r",
+        ) as fp:
             variables_read_dict = {
                 "MultiParticleLiquid": False,
                 "MultiParticleGas": False,
@@ -2471,7 +2484,9 @@ class TestGOMCControlFileWriter(BaseTest):
             "MultiParticleGas": True,
         }
 
-    def test_save_change_most_variable_GEMC_NPT_mulitparticle_settings_both_true(self, ethane_gomc, ethanol_gomc):
+    def test_save_change_most_variable_GEMC_NPT_mulitparticle_settings_both_true(
+        self, ethane_gomc, ethanol_gomc
+    ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
             n_compounds=[1, 1],
@@ -2507,7 +2522,10 @@ class TestGOMCControlFileWriter(BaseTest):
             },
         )
 
-        with open("test_save_change_most_variable_GEMC_NPT_mulitparticle_settings_both_true.conf", "r") as fp:
+        with open(
+            "test_save_change_most_variable_GEMC_NPT_mulitparticle_settings_both_true.conf",
+            "r",
+        ) as fp:
             variables_read_dict = {
                 "MultiParticleLiquid": False,
                 "MultiParticleGas": False,
@@ -2532,7 +2550,9 @@ class TestGOMCControlFileWriter(BaseTest):
             "MultiParticleGas": True,
         }
 
-    def test_save_change_most_variable_GEMC_NPT_mulitparticle_not_printed_for_NVT(self, ethane_gomc, ethanol_gomc):
+    def test_save_change_most_variable_GEMC_NPT_mulitparticle_not_printed_for_NVT(
+        self, ethane_gomc, ethanol_gomc
+    ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
             n_compounds=[1, 1],
@@ -2546,13 +2566,13 @@ class TestGOMCControlFileWriter(BaseTest):
             forcefield_selection="oplsaa",
         )
         with pytest.raises(
-                ValueError,
-                match=r"ERROR: All the correct input variables where not provided for "
-                      r"the NVT ensemble. Please be sure to check that the keys in the "
-                      r"input variables dictionary \(input_variables_dict\) is correct, and "
-                      r"be aware that added spaces before or after the variable in any keys "
-                      r"will also give this warning. The bad variable inputs ensemble "
-                      r"inputs = \['MultiParticleLiquid', 'MultiParticleGas'\]",
+            ValueError,
+            match=r"ERROR: All the correct input variables where not provided for "
+            r"the NVT ensemble. Please be sure to check that the keys in the "
+            r"input variables dictionary \(input_variables_dict\) is correct, and "
+            r"be aware that added spaces before or after the variable in any keys "
+            r"will also give this warning. The bad variable inputs ensemble "
+            r"inputs = \['MultiParticleLiquid', 'MultiParticleGas'\]",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -2574,7 +2594,9 @@ class TestGOMCControlFileWriter(BaseTest):
                 },
             )
 
-    def test_save_change_most_variable_GEMC_NPT_bad_mulitparticle_liquid_setting(self, ethane_gomc, ethanol_gomc):
+    def test_save_change_most_variable_GEMC_NPT_bad_mulitparticle_liquid_setting(
+        self, ethane_gomc, ethanol_gomc
+    ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
             n_compounds=[1, 1],
@@ -2591,11 +2613,11 @@ class TestGOMCControlFileWriter(BaseTest):
         )
 
         with pytest.raises(
-                ValueError,
-                match=r"ERROR: The following input variables have "
-                      r"bad values \(check spelling and for empty spaces in the keys or that "
-                      r"the values are in the correct form with the acceptable values\)"
-                      r": \['MultiParticleLiquid'\]",
+            ValueError,
+            match=r"ERROR: The following input variables have "
+            r"bad values \(check spelling and for empty spaces in the keys or that "
+            r"the values are in the correct form with the acceptable values\)"
+            r": \['MultiParticleLiquid'\]",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -2617,7 +2639,9 @@ class TestGOMCControlFileWriter(BaseTest):
                 },
             )
 
-    def test_save_change_most_variable_GEMC_NPT_bad_mulitparticle_gas_setting(self, ethane_gomc, ethanol_gomc):
+    def test_save_change_most_variable_GEMC_NPT_bad_mulitparticle_gas_setting(
+        self, ethane_gomc, ethanol_gomc
+    ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
             n_compounds=[1, 1],

--- a/mosdef_gomc/tests/test_gmso_gomc_conf_writer.py
+++ b/mosdef_gomc/tests/test_gmso_gomc_conf_writer.py
@@ -1728,7 +1728,7 @@ class TestGOMCControlFileWriter(BaseTest):
             "RcutCoulomb_box_1": True,
         }
 
-    def test_save_change_most_variable_NVT(self, ethane_gomc, ethanol_gomc):
+    def test_save_change_most_variable_NVT_mulitparticle(self, ethane_gomc, ethanol_gomc):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
             n_compounds=[1, 1],
@@ -1744,7 +1744,7 @@ class TestGOMCControlFileWriter(BaseTest):
 
         gomc_control.write_gomc_control_file(
             charmm,
-            "test_save_change_most_variable_NVT.conf",
+            "test_save_change_most_variable_NVT_mulitparticle.conf",
             "NVT",
             100000,
             300 * u.K,
@@ -1810,7 +1810,7 @@ class TestGOMCControlFileWriter(BaseTest):
             },
         )
 
-        with open("test_save_change_most_variable_NVT.conf", "r") as fp:
+        with open("test_save_change_most_variable_NVT_mulitparticle.conf", "r") as fp:
             variables_read_dict = {
                 "Restart": False,
                 "ExpertMode": False,
@@ -2349,6 +2349,316 @@ class TestGOMCControlFileWriter(BaseTest):
             "OutVolume": True,
             "OutSurfaceTension": True,
         }
+
+    def test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_default(self, ethane_gomc, ethanol_gomc):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            structure_box_1=test_box_ethane_ethanol,
+            filename_box_1="ethane_ethanol_box_1",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        gomc_control.write_gomc_control_file(
+            charmm,
+            "test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_default",
+            "GEMC-NVT",
+            100000,
+            300 * u.K,
+            check_input_files_exist=False,
+            Restart=False,
+            input_variables_dict={
+                "DisFreq": 0.2,
+                "RotFreq": 0.2,
+                "IntraSwapFreq": 0.25,
+                "RegrowthFreq": 0.1,
+                "CrankShaftFreq": 0.2,
+                "MultiParticleFreq": 0.05,
+            },
+        )
+
+        with open("test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_default.conf", "r") as fp:
+            variables_read_dict = {
+                "MultiParticleLiquid": False,
+                "MultiParticleGas": False,
+            }
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if line.startswith("MultiParticleLiquid "):
+                    variables_read_dict["MultiParticleLiquid"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "True"
+
+                elif line.startswith("MultiParticleGas "):
+                    variables_read_dict["MultiParticleGas"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "False"
+
+                else:
+                    pass
+
+        assert variables_read_dict == {
+            "MultiParticleLiquid": True,
+            "MultiParticleGas": True,
+        }
+
+
+    def test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_both_false(self, ethane_gomc, ethanol_gomc):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            structure_box_1=test_box_ethane_ethanol,
+            filename_box_1="ethane_ethanol_box_1",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        gomc_control.write_gomc_control_file(
+            charmm,
+            "test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_both_false.conf",
+            "GEMC-NVT",
+            100000,
+            300 * u.K,
+            check_input_files_exist=False,
+            Restart=False,
+            input_variables_dict={
+                "DisFreq": 0.2,
+                "RotFreq": 0.2,
+                "IntraSwapFreq": 0.25,
+                "RegrowthFreq": 0.1,
+                "CrankShaftFreq": 0.2,
+                "MultiParticleFreq": 0.05,
+                "MultiParticleLiquid": False,
+                "MultiParticleGas": False,
+            },
+        )
+
+        with open("test_save_change_most_variable_GEMC_NVT_mulitparticle_settings_both_false.conf", "r") as fp:
+            variables_read_dict = {
+                "MultiParticleLiquid": False,
+                "MultiParticleGas": False,
+            }
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if line.startswith("MultiParticleLiquid "):
+                    variables_read_dict["MultiParticleLiquid"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "False"
+
+                elif line.startswith("MultiParticleGas "):
+                    variables_read_dict["MultiParticleGas"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "False"
+
+                else:
+                    pass
+
+        assert variables_read_dict == {
+            "MultiParticleLiquid": True,
+            "MultiParticleGas": True,
+        }
+
+    def test_save_change_most_variable_GEMC_NPT_mulitparticle_settings_both_true(self, ethane_gomc, ethanol_gomc):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            structure_box_1=test_box_ethane_ethanol,
+            filename_box_1="ethane_ethanol_box_1",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        gomc_control.write_gomc_control_file(
+            charmm,
+            "test_save_change_most_variable_GEMC_NPT_mulitparticle_settings_both_true.conf",
+            "GEMC-NPT",
+            100000,
+            300 * u.K,
+            check_input_files_exist=False,
+            Restart=False,
+            input_variables_dict={
+                "DisFreq": 0.2,
+                "RotFreq": 0.2,
+                "IntraSwapFreq": 0.25,
+                "RegrowthFreq": 0.1,
+                "CrankShaftFreq": 0.2,
+                "MultiParticleFreq": 0.05,
+                "MultiParticleLiquid": True,
+                "MultiParticleGas": True,
+            },
+        )
+
+        with open("test_save_change_most_variable_GEMC_NPT_mulitparticle_settings_both_true.conf", "r") as fp:
+            variables_read_dict = {
+                "MultiParticleLiquid": False,
+                "MultiParticleGas": False,
+            }
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if line.startswith("MultiParticleLiquid "):
+                    variables_read_dict["MultiParticleLiquid"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "True"
+
+                elif line.startswith("MultiParticleGas "):
+                    variables_read_dict["MultiParticleGas"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "True"
+
+                else:
+                    pass
+
+        assert variables_read_dict == {
+            "MultiParticleLiquid": True,
+            "MultiParticleGas": True,
+        }
+
+    def test_save_change_most_variable_GEMC_NPT_mulitparticle_not_printed_for_NVT(self, ethane_gomc, ethanol_gomc):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+        with pytest.raises(
+                ValueError,
+                match=r"ERROR: All the correct input variables where not provided for "
+                      r"the NVT ensemble. Please be sure to check that the keys in the "
+                      r"input variables dictionary \(input_variables_dict\) is correct, and "
+                      r"be aware that added spaces before or after the variable in any keys "
+                      r"will also give this warning. The bad variable inputs ensemble "
+                      r"inputs = \['MultiParticleLiquid', 'MultiParticleGas'\]",
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_save_change_most_variable_GEMC_NPT_mulitparticle_not_printed_for_NVT.conf",
+                "NVT",
+                100000,
+                300 * u.K,
+                check_input_files_exist=False,
+                Restart=False,
+                input_variables_dict={
+                    "DisFreq": 0.2,
+                    "RotFreq": 0.2,
+                    "IntraSwapFreq": 0.25,
+                    "RegrowthFreq": 0.1,
+                    "CrankShaftFreq": 0.2,
+                    "MultiParticleFreq": 0.05,
+                    "MultiParticleLiquid": False,
+                    "MultiParticleGas": False,
+                },
+            )
+
+    def test_save_change_most_variable_GEMC_NPT_bad_mulitparticle_liquid_setting(self, ethane_gomc, ethanol_gomc):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            structure_box_1=test_box_ethane_ethanol,
+            filename_box_1="ethane_ethanol_box_1",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        with pytest.raises(
+                ValueError,
+                match=r"ERROR: The following input variables have "
+                      r"bad values \(check spelling and for empty spaces in the keys or that "
+                      r"the values are in the correct form with the acceptable values\)"
+                      r": \['MultiParticleLiquid'\]",
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_save_change_most_variable_GEMC_NPT_bad_mulitparticle_liquid_setting.conf",
+                "GEMC-NPT",
+                100000,
+                300 * u.K,
+                check_input_files_exist=False,
+                Restart=False,
+                input_variables_dict={
+                    "DisFreq": 0.2,
+                    "RotFreq": 0.2,
+                    "IntraSwapFreq": 0.25,
+                    "RegrowthFreq": 0.1,
+                    "CrankShaftFreq": 0.2,
+                    "MultiParticleFreq": 0.05,
+                    "MultiParticleLiquid": "s",
+                    "MultiParticleGas": False,
+                },
+            )
+
+    def test_save_change_most_variable_GEMC_NPT_bad_mulitparticle_gas_setting(self, ethane_gomc, ethanol_gomc):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            structure_box_1=test_box_ethane_ethanol,
+            filename_box_1="ethane_ethanol_box_1",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=r"ERROR: The following input variables have "
+            r"bad values \(check spelling and for empty spaces in the keys or that "
+            r"the values are in the correct form with the acceptable values\)"
+            r": \['MultiParticleGas'\]",
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_save_change_most_variable_GEMC_NPT_bad_mulitparticle_gas_setting.conf",
+                "GEMC-NPT",
+                100000,
+                300 * u.K,
+                check_input_files_exist=False,
+                Restart=False,
+                input_variables_dict={
+                    "DisFreq": 0.2,
+                    "RotFreq": 0.2,
+                    "IntraSwapFreq": 0.25,
+                    "RegrowthFreq": 0.1,
+                    "CrankShaftFreq": 0.2,
+                    "MultiParticleFreq": 0.05,
+                    "MultiParticleLiquid": False,
+                    "MultiParticleGas": "s",
+                },
+            )
 
     def test_save_NVT_bad_lamda_value(self, ethane_gomc, ethanol_gomc):
         test_box_ethane_ethanol = mb.fill_box(

--- a/mosdef_gomc/tests/test_gmso_gomc_conf_writer.py
+++ b/mosdef_gomc/tests/test_gmso_gomc_conf_writer.py
@@ -2685,7 +2685,7 @@ class TestGOMCControlFileWriter(BaseTest):
             )
 
     def test_save_change_most_variable_GEMC_NVT_mulitparticlebrownian_settings_default(
-            self, ethane_gomc, ethanol_gomc
+        self, ethane_gomc, ethanol_gomc
     ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
@@ -2721,8 +2721,8 @@ class TestGOMCControlFileWriter(BaseTest):
         )
 
         with open(
-                "test_save_change_most_variable_GEMC_NVT_mulitparticlebrownian_settings_default.conf",
-                "r",
+            "test_save_change_most_variable_GEMC_NVT_mulitparticlebrownian_settings_default.conf",
+            "r",
         ) as fp:
             variables_read_dict = {
                 "MultiParticleLiquid": False,
@@ -2748,9 +2748,8 @@ class TestGOMCControlFileWriter(BaseTest):
             "MultiParticleGas": True,
         }
 
-
     def test_save_change_most_variable_GEMC_NVT_mulitparticlebrownian_settings_both_false(
-            self, ethane_gomc, ethanol_gomc
+        self, ethane_gomc, ethanol_gomc
     ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
@@ -2788,8 +2787,8 @@ class TestGOMCControlFileWriter(BaseTest):
         )
 
         with open(
-                "test_save_change_most_variable_GEMC_NVT_mulitparticlebrownian_settings_both_false.conf",
-                "r",
+            "test_save_change_most_variable_GEMC_NVT_mulitparticlebrownian_settings_both_false.conf",
+            "r",
         ) as fp:
             variables_read_dict = {
                 "MultiParticleLiquid": False,
@@ -2815,9 +2814,8 @@ class TestGOMCControlFileWriter(BaseTest):
             "MultiParticleGas": True,
         }
 
-
     def test_save_change_most_variable_GEMC_NPT_mulitparticlebrownian_settings_both_true(
-            self, ethane_gomc, ethanol_gomc
+        self, ethane_gomc, ethanol_gomc
     ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
@@ -2855,8 +2853,8 @@ class TestGOMCControlFileWriter(BaseTest):
         )
 
         with open(
-                "test_save_change_most_variable_GEMC_NPT_mulitparticlebrownian_settings_both_true.conf",
-                "r",
+            "test_save_change_most_variable_GEMC_NPT_mulitparticlebrownian_settings_both_true.conf",
+            "r",
         ) as fp:
             variables_read_dict = {
                 "MultiParticleLiquid": False,
@@ -2882,9 +2880,8 @@ class TestGOMCControlFileWriter(BaseTest):
             "MultiParticleGas": True,
         }
 
-
     def test_save_change_most_variable_GEMC_NPT_mulitparticlebrownian_not_printed_for_NVT(
-            self, ethane_gomc, ethanol_gomc
+        self, ethane_gomc, ethanol_gomc
     ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
@@ -2899,13 +2896,13 @@ class TestGOMCControlFileWriter(BaseTest):
             forcefield_selection="oplsaa",
         )
         with pytest.raises(
-                ValueError,
-                match=r"ERROR: All the correct input variables where not provided for "
-                      r"the NVT ensemble. Please be sure to check that the keys in the "
-                      r"input variables dictionary \(input_variables_dict\) is correct, and "
-                      r"be aware that added spaces before or after the variable in any keys "
-                      r"will also give this warning. The bad variable inputs ensemble "
-                      r"inputs = \['MultiParticleLiquid', 'MultiParticleGas'\]",
+            ValueError,
+            match=r"ERROR: All the correct input variables where not provided for "
+            r"the NVT ensemble. Please be sure to check that the keys in the "
+            r"input variables dictionary \(input_variables_dict\) is correct, and "
+            r"be aware that added spaces before or after the variable in any keys "
+            r"will also give this warning. The bad variable inputs ensemble "
+            r"inputs = \['MultiParticleLiquid', 'MultiParticleGas'\]",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -2927,9 +2924,8 @@ class TestGOMCControlFileWriter(BaseTest):
                 },
             )
 
-
     def test_save_change_most_variable_GEMC_NPT_bad_mulitparticlebrownian_liquid_setting(
-            self, ethane_gomc, ethanol_gomc
+        self, ethane_gomc, ethanol_gomc
     ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
@@ -2947,11 +2943,11 @@ class TestGOMCControlFileWriter(BaseTest):
         )
 
         with pytest.raises(
-                ValueError,
-                match=r"ERROR: The following input variables have "
-                      r"bad values \(check spelling and for empty spaces in the keys or that "
-                      r"the values are in the correct form with the acceptable values\)"
-                      r": \['MultiParticleLiquid'\]",
+            ValueError,
+            match=r"ERROR: The following input variables have "
+            r"bad values \(check spelling and for empty spaces in the keys or that "
+            r"the values are in the correct form with the acceptable values\)"
+            r": \['MultiParticleLiquid'\]",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -2973,9 +2969,8 @@ class TestGOMCControlFileWriter(BaseTest):
                 },
             )
 
-
     def test_save_change_most_variable_GEMC_NPT_bad_mulitparticlebrownian_gas_setting(
-            self, ethane_gomc, ethanol_gomc
+        self, ethane_gomc, ethanol_gomc
     ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
@@ -2993,11 +2988,11 @@ class TestGOMCControlFileWriter(BaseTest):
         )
 
         with pytest.raises(
-                ValueError,
-                match=r"ERROR: The following input variables have "
-                      r"bad values \(check spelling and for empty spaces in the keys or that "
-                      r"the values are in the correct form with the acceptable values\)"
-                      r": \['MultiParticleGas'\]",
+            ValueError,
+            match=r"ERROR: The following input variables have "
+            r"bad values \(check spelling and for empty spaces in the keys or that "
+            r"the values are in the correct form with the acceptable values\)"
+            r": \['MultiParticleGas'\]",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -3020,7 +3015,7 @@ class TestGOMCControlFileWriter(BaseTest):
             )
 
     def test_save_change_most_variable_GEMC_NPT_bad_mulitparticle_and_mulitparticlebrownian(
-            self, ethane_gomc, ethanol_gomc
+        self, ethane_gomc, ethanol_gomc
     ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
@@ -3038,9 +3033,9 @@ class TestGOMCControlFileWriter(BaseTest):
         )
 
         with pytest.raises(
-                ValueError,
-                match=r"ERROR: Both MultiParticle \(MultiParticleFreq\) and MultiParticleBrownian "
-                      r"\(MultiParticleBrownianFreq\) cannot be used at the same time.",
+            ValueError,
+            match=r"ERROR: Both MultiParticle \(MultiParticleFreq\) and MultiParticleBrownian "
+            r"\(MultiParticleBrownianFreq\) cannot be used at the same time.",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,
@@ -3064,7 +3059,7 @@ class TestGOMCControlFileWriter(BaseTest):
             )
 
     def test_save_GEMC_NPT_bad_mulitparticlebrownian_freq_greater_than_1(
-            self, ethane_gomc, ethanol_gomc
+        self, ethane_gomc, ethanol_gomc
     ):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],
@@ -3082,15 +3077,15 @@ class TestGOMCControlFileWriter(BaseTest):
         )
 
         with pytest.raises(
-                ValueError,
-                match= r"ERROR: The sum of the Monte Carlo move ratios does not equal 1. "
-                       r"Note: The sum that was manually entered may equal 1, but some "
-                       r"moves may not be valid for the provided ensemble. The moves "
-                       r"that are invalid for a given ensemble are set to zero. If "
-                       r"the default moves are not being used, all the move frequencies "
-                       r"which do not have default values of zero will need to be set manually "
-                       r"so the sum equals \(DisFreq, RotFreq, IntraSwapFreq, SwapFreq, "
-                       r"RegrowthFreq, CrankShaftFreq, and VolFreq\).",
+            ValueError,
+            match=r"ERROR: The sum of the Monte Carlo move ratios does not equal 1. "
+            r"Note: The sum that was manually entered may equal 1, but some "
+            r"moves may not be valid for the provided ensemble. The moves "
+            r"that are invalid for a given ensemble are set to zero. If "
+            r"the default moves are not being used, all the move frequencies "
+            r"which do not have default values of zero will need to be set manually "
+            r"so the sum equals \(DisFreq, RotFreq, IntraSwapFreq, SwapFreq, "
+            r"RegrowthFreq, CrankShaftFreq, and VolFreq\).",
         ):
             gomc_control.write_gomc_control_file(
                 charmm,

--- a/mosdef_gomc/tests/test_gmso_gomc_conf_writer.py
+++ b/mosdef_gomc/tests/test_gmso_gomc_conf_writer.py
@@ -2684,6 +2684,434 @@ class TestGOMCControlFileWriter(BaseTest):
                 },
             )
 
+    def test_save_change_most_variable_GEMC_NVT_mulitparticlebrownian_settings_default(
+            self, ethane_gomc, ethanol_gomc
+    ):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            structure_box_1=test_box_ethane_ethanol,
+            filename_box_1="ethane_ethanol_box_1",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        gomc_control.write_gomc_control_file(
+            charmm,
+            "test_save_change_most_variable_GEMC_NVT_mulitparticlebrownian_settings_default",
+            "GEMC-NVT",
+            100000,
+            300 * u.K,
+            check_input_files_exist=False,
+            Restart=False,
+            input_variables_dict={
+                "DisFreq": 0.2,
+                "RotFreq": 0.2,
+                "IntraSwapFreq": 0.25,
+                "RegrowthFreq": 0.1,
+                "CrankShaftFreq": 0.2,
+                "MultiParticleBrownianFreq": 0.05,
+            },
+        )
+
+        with open(
+                "test_save_change_most_variable_GEMC_NVT_mulitparticlebrownian_settings_default.conf",
+                "r",
+        ) as fp:
+            variables_read_dict = {
+                "MultiParticleLiquid": False,
+                "MultiParticleGas": False,
+            }
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if line.startswith("MultiParticleLiquid "):
+                    variables_read_dict["MultiParticleLiquid"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "True"
+
+                elif line.startswith("MultiParticleGas "):
+                    variables_read_dict["MultiParticleGas"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "False"
+
+                else:
+                    pass
+
+        assert variables_read_dict == {
+            "MultiParticleLiquid": True,
+            "MultiParticleGas": True,
+        }
+
+
+    def test_save_change_most_variable_GEMC_NVT_mulitparticlebrownian_settings_both_false(
+            self, ethane_gomc, ethanol_gomc
+    ):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            structure_box_1=test_box_ethane_ethanol,
+            filename_box_1="ethane_ethanol_box_1",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        gomc_control.write_gomc_control_file(
+            charmm,
+            "test_save_change_most_variable_GEMC_NVT_mulitparticlebrownian_settings_both_false.conf",
+            "GEMC-NVT",
+            100000,
+            300 * u.K,
+            check_input_files_exist=False,
+            Restart=False,
+            input_variables_dict={
+                "DisFreq": 0.2,
+                "RotFreq": 0.2,
+                "IntraSwapFreq": 0.25,
+                "RegrowthFreq": 0.1,
+                "CrankShaftFreq": 0.2,
+                "MultiParticleBrownianFreq": 0.05,
+                "MultiParticleLiquid": False,
+                "MultiParticleGas": False,
+            },
+        )
+
+        with open(
+                "test_save_change_most_variable_GEMC_NVT_mulitparticlebrownian_settings_both_false.conf",
+                "r",
+        ) as fp:
+            variables_read_dict = {
+                "MultiParticleLiquid": False,
+                "MultiParticleGas": False,
+            }
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if line.startswith("MultiParticleLiquid "):
+                    variables_read_dict["MultiParticleLiquid"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "False"
+
+                elif line.startswith("MultiParticleGas "):
+                    variables_read_dict["MultiParticleGas"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "False"
+
+                else:
+                    pass
+
+        assert variables_read_dict == {
+            "MultiParticleLiquid": True,
+            "MultiParticleGas": True,
+        }
+
+
+    def test_save_change_most_variable_GEMC_NPT_mulitparticlebrownian_settings_both_true(
+            self, ethane_gomc, ethanol_gomc
+    ):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            structure_box_1=test_box_ethane_ethanol,
+            filename_box_1="ethane_ethanol_box_1",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        gomc_control.write_gomc_control_file(
+            charmm,
+            "test_save_change_most_variable_GEMC_NPT_mulitparticlebrownian_settings_both_true.conf",
+            "GEMC-NPT",
+            100000,
+            300 * u.K,
+            check_input_files_exist=False,
+            Restart=False,
+            input_variables_dict={
+                "DisFreq": 0.2,
+                "RotFreq": 0.2,
+                "IntraSwapFreq": 0.25,
+                "RegrowthFreq": 0.1,
+                "CrankShaftFreq": 0.2,
+                "MultiParticleBrownianFreq": 0.05,
+                "MultiParticleLiquid": True,
+                "MultiParticleGas": True,
+            },
+        )
+
+        with open(
+                "test_save_change_most_variable_GEMC_NPT_mulitparticlebrownian_settings_both_true.conf",
+                "r",
+        ) as fp:
+            variables_read_dict = {
+                "MultiParticleLiquid": False,
+                "MultiParticleGas": False,
+            }
+            out_gomc = fp.readlines()
+            for i, line in enumerate(out_gomc):
+                if line.startswith("MultiParticleLiquid "):
+                    variables_read_dict["MultiParticleLiquid"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "True"
+
+                elif line.startswith("MultiParticleGas "):
+                    variables_read_dict["MultiParticleGas"] = True
+                    split_line = line.split()
+                    assert split_line[1] == "True"
+
+                else:
+                    pass
+
+        assert variables_read_dict == {
+            "MultiParticleLiquid": True,
+            "MultiParticleGas": True,
+        }
+
+
+    def test_save_change_most_variable_GEMC_NPT_mulitparticlebrownian_not_printed_for_NVT(
+            self, ethane_gomc, ethanol_gomc
+    ):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+        with pytest.raises(
+                ValueError,
+                match=r"ERROR: All the correct input variables where not provided for "
+                      r"the NVT ensemble. Please be sure to check that the keys in the "
+                      r"input variables dictionary \(input_variables_dict\) is correct, and "
+                      r"be aware that added spaces before or after the variable in any keys "
+                      r"will also give this warning. The bad variable inputs ensemble "
+                      r"inputs = \['MultiParticleLiquid', 'MultiParticleGas'\]",
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_save_change_most_variable_GEMC_NPT_mulitparticlebrownian_not_printed_for_NVT.conf",
+                "NVT",
+                100000,
+                300 * u.K,
+                check_input_files_exist=False,
+                Restart=False,
+                input_variables_dict={
+                    "DisFreq": 0.2,
+                    "RotFreq": 0.2,
+                    "IntraSwapFreq": 0.25,
+                    "RegrowthFreq": 0.1,
+                    "CrankShaftFreq": 0.2,
+                    "MultiParticleBrownianFreq": 0.05,
+                    "MultiParticleLiquid": False,
+                    "MultiParticleGas": False,
+                },
+            )
+
+
+    def test_save_change_most_variable_GEMC_NPT_bad_mulitparticlebrownian_liquid_setting(
+            self, ethane_gomc, ethanol_gomc
+    ):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            structure_box_1=test_box_ethane_ethanol,
+            filename_box_1="ethane_ethanol_box_1",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        with pytest.raises(
+                ValueError,
+                match=r"ERROR: The following input variables have "
+                      r"bad values \(check spelling and for empty spaces in the keys or that "
+                      r"the values are in the correct form with the acceptable values\)"
+                      r": \['MultiParticleLiquid'\]",
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_save_change_most_variable_GEMC_NPT_bad_mulitparticlebrownian_liquid_setting.conf",
+                "GEMC-NPT",
+                100000,
+                300 * u.K,
+                check_input_files_exist=False,
+                Restart=False,
+                input_variables_dict={
+                    "DisFreq": 0.2,
+                    "RotFreq": 0.2,
+                    "IntraSwapFreq": 0.25,
+                    "RegrowthFreq": 0.1,
+                    "CrankShaftFreq": 0.2,
+                    "MultiParticleBrownianFreq": 0.05,
+                    "MultiParticleLiquid": "s",
+                    "MultiParticleGas": False,
+                },
+            )
+
+
+    def test_save_change_most_variable_GEMC_NPT_bad_mulitparticlebrownian_gas_setting(
+            self, ethane_gomc, ethanol_gomc
+    ):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            structure_box_1=test_box_ethane_ethanol,
+            filename_box_1="ethane_ethanol_box_1",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        with pytest.raises(
+                ValueError,
+                match=r"ERROR: The following input variables have "
+                      r"bad values \(check spelling and for empty spaces in the keys or that "
+                      r"the values are in the correct form with the acceptable values\)"
+                      r": \['MultiParticleGas'\]",
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_save_change_most_variable_GEMC_NPT_bad_mulitparticlebrownian_gas_setting.conf",
+                "GEMC-NPT",
+                100000,
+                300 * u.K,
+                check_input_files_exist=False,
+                Restart=False,
+                input_variables_dict={
+                    "DisFreq": 0.2,
+                    "RotFreq": 0.2,
+                    "IntraSwapFreq": 0.25,
+                    "RegrowthFreq": 0.1,
+                    "CrankShaftFreq": 0.2,
+                    "MultiParticleFreq": 0.05,
+                    "MultiParticleLiquid": False,
+                    "MultiParticleGas": "s",
+                },
+            )
+
+    def test_save_change_most_variable_GEMC_NPT_bad_mulitparticle_and_mulitparticlebrownian(
+            self, ethane_gomc, ethanol_gomc
+    ):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            structure_box_1=test_box_ethane_ethanol,
+            filename_box_1="ethane_ethanol_box_1",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        with pytest.raises(
+                ValueError,
+                match=r"ERROR: Both MultiParticle \(MultiParticleFreq\) and MultiParticleBrownian "
+                      r"\(MultiParticleBrownianFreq\) cannot be used at the same time.",
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_save_change_most_variable_GEMC_NPT_bad_mulitparticle_and_mulitparticlebrownian.conf",
+                "GEMC-NPT",
+                100000,
+                300 * u.K,
+                check_input_files_exist=False,
+                Restart=False,
+                input_variables_dict={
+                    "DisFreq": 0.2,
+                    "RotFreq": 0.2,
+                    "IntraSwapFreq": 0.25,
+                    "RegrowthFreq": 0.1,
+                    "CrankShaftFreq": 0.2,
+                    "MultiParticleFreq": 0.025,
+                    "MultiParticleBrownianFreq": 0.025,
+                    "MultiParticleLiquid": True,
+                    "MultiParticleGas": False,
+                },
+            )
+
+    def test_save_GEMC_NPT_bad_mulitparticlebrownian_freq_greater_than_1(
+            self, ethane_gomc, ethanol_gomc
+    ):
+        test_box_ethane_ethanol = mb.fill_box(
+            compound=[ethane_gomc, ethanol_gomc],
+            n_compounds=[1, 1],
+            box=[4.0, 4.0, 4.0],
+        )
+        charmm = Charmm(
+            test_box_ethane_ethanol,
+            "ethane_ethanol_box_0",
+            structure_box_1=test_box_ethane_ethanol,
+            filename_box_1="ethane_ethanol_box_1",
+            ff_filename="ethane_ethanol_FF",
+            residues=[ethane_gomc.name, ethanol_gomc.name],
+            forcefield_selection="oplsaa",
+        )
+
+        with pytest.raises(
+                ValueError,
+                match= r"ERROR: The sum of the Monte Carlo move ratios does not equal 1. "
+                       r"Note: The sum that was manually entered may equal 1, but some "
+                       r"moves may not be valid for the provided ensemble. The moves "
+                       r"that are invalid for a given ensemble are set to zero. If "
+                       r"the default moves are not being used, all the move frequencies "
+                       r"which do not have default values of zero will need to be set manually "
+                       r"so the sum equals \(DisFreq, RotFreq, IntraSwapFreq, SwapFreq, "
+                       r"RegrowthFreq, CrankShaftFreq, and VolFreq\).",
+        ):
+            gomc_control.write_gomc_control_file(
+                charmm,
+                "test_save_GEMC_NPT_bad_mulitparticlebrownian_freq_greater_than_1.conf",
+                "GEMC-NPT",
+                100000,
+                300 * u.K,
+                check_input_files_exist=False,
+                Restart=False,
+                input_variables_dict={
+                    "DisFreq": 0.2,
+                    "RotFreq": 0.2,
+                    "IntraSwapFreq": 0.25,
+                    "RegrowthFreq": 0.1,
+                    "CrankShaftFreq": 0.2,
+                    "MultiParticleBrownianFreq": 0.051,
+                    "MultiParticleLiquid": True,
+                    "MultiParticleGas": False,
+                },
+            )
+
     def test_save_NVT_bad_lamda_value(self, ethane_gomc, ethanol_gomc):
         test_box_ethane_ethanol = mb.fill_box(
             compound=[ethane_gomc, ethanol_gomc],


### PR DESCRIPTION
- MulitParticle Brownian was added. 
- Added the GOMC  MultiParticle and MulitParticleBrownian move flags for GEMC-NVT and GEMC-NPT.

This adds the new GOMC MultiParticleLiquid (default=True) and MultiParticleGas (default=False) flags used in the GEMC options (GEMC-NVT and GEMC-NPT) for GOMC to MoSDeF-GOMC conf file writer.  It errors if entered for any other Ensemble (NVT, NPT, or GCMC).  

Note: these are only printed if (if this is not correct, let me know:
 - MultiParticleFreq > 0 or MulitParticleBrownianFreq > 0 and self.ensemble_type in [ "GEMC_NPT", "GEMC_NVT"]

**_This can be merged after the GOMC PR (https://github.com/GOMC-WSU/GOMC/issues/520) in merged, which adds these features._**