### PR TITLE
update to python 3.10 and 3.11 and update GMSO version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10", "3.11"]
         os: ["ubuntu", "macos"]
         include:
           - os: ubuntu

--- a/docs/environment_docs.yml
+++ b/docs/environment_docs.yml
@@ -17,10 +17,10 @@ dependencies:
   - sympy
   - symengine
   - python-symengine
-  - python>=3.9,<=3.10
+  - python>=3.10,<=3.11
   - forcefield-utilities>=0.3.0
   - foyer>=0.12.1
-  - gmso>=0.12.0
+  - gmso>=0.12.1
   - mbuild>=0.17.0
   - pre-commit
   - sphinx=6.1.1

--- a/docs/getting_started/installation/installation.rst
+++ b/docs/getting_started/installation/installation.rst
@@ -8,13 +8,13 @@ Install with `mamba <https://github.com/mamba-org/mamba>`_ (Recommended)
 ------------------------------------------------------------------------
 ::
 
-    $ conda create --name mosdef_gomc python=3.10
+    $ conda create --name mosdef_gomc python=3.11
 
     $ conda activate mosdef_gomc
 
     $ conda install -c conda-forge mamba
 
-    $ mamba install -c conda-forge mosdef-gomc python=3.10
+    $ mamba install -c conda-forge mosdef-gomc python=3.11
 
 
 Install with `conda <https://repo.anaconda.com/miniconda/>`_
@@ -56,8 +56,8 @@ To check all the file, you can run::
 Supported Python Versions
 -------------------------
 
-Python 3.9 and 3.10 are officially supported and tested during development and with the final product.
-Python versions older than 3.9 may work, but there is no guarantee.
+Python 3.10 and 3.11 are officially supported and tested during development and with the final product.
+Python versions older than 3.10 may work, but there is no guarantee.
 
 Testing your installation
 -------------------------

--- a/environment.yml
+++ b/environment.yml
@@ -17,10 +17,10 @@ dependencies:
   - sympy
   - symengine
   - python-symengine
-  - python>=3.9,<=3.10
+  - python>=3.10,<=3.11
   - forcefield-utilities>=0.3.0
   - foyer>=0.12.1
-  - gmso>=0.12.0
+  - gmso>=0.12.1
   - mbuild>=0.17.0
   - pre-commit
   - sphinx=6.1.1


### PR DESCRIPTION
- updated to Python 3.10 and 3.11
- update GMSO version, which fixes the mixed ordering of the atoms in the improper (fixed gmso bug in version 0.12.1)