### PR TITLE
'symengine.sympify' changed to  'sympy.nsimplify' to solve for non-integers

### DIFF
--- a/mosdef_gomc/utils/gmso_equation_compare.py
+++ b/mosdef_gomc/utils/gmso_equation_compare.py
@@ -10,6 +10,7 @@ import unyt as u
 # Although,'symengine.sympify' from 'import symengine ' is faster, it was changed to 'sympy.nsimplify' as it changes
 # improves the solving of the code by also solving 0.5 or other non-integers with integers.
 
+
 # compare Lennard-Jones (LJ) non-bonded equations
 def evaluate_nonbonded_lj_format_with_scaler(new_lj_form, base_lj_form):
     """Compare a new Lennard-Jones (LJ) form to a base LJ form (new LJ form / base LJ form).
@@ -45,8 +46,7 @@ def evaluate_nonbonded_lj_format_with_scaler(new_lj_form, base_lj_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_lj_form)
-                / sympy.nsimplify(base_lj_form),
+                - sympy.nsimplify(new_lj_form) / sympy.nsimplify(base_lj_form),
                 Rmin - sigma * two ** (1 / 6),
                 two - 2,
             ],

--- a/mosdef_gomc/utils/gmso_equation_compare.py
+++ b/mosdef_gomc/utils/gmso_equation_compare.py
@@ -48,7 +48,7 @@ def evaluate_nonbonded_lj_format_with_scaler(new_lj_form, base_lj_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - symengine.sympify(new_lj_form) 
+                - symengine.sympify(new_lj_form)
                 / symengine.sympify(base_lj_form),
                 Rmin - sigma * two ** (1 / 6),
                 two - 2,

--- a/mosdef_gomc/utils/gmso_equation_compare.py
+++ b/mosdef_gomc/utils/gmso_equation_compare.py
@@ -9,8 +9,8 @@ import sympy
 import unyt as u
 
 # Although,'symengine.sympify' from 'import symengine ' is faster, it was changed to 'sympy.nsimplify' for some
-# with the 0.5 decimals in it like as it changes
-# improves the solving of the code by also solving 0.5 or other non-integers with integers.
+# less simple equations with the 0.5 decimals in it (example OPLS dihedral).  This was the only was to improve
+# or actually solve for the scalers in the equations when using non-integers in the forms like the OPLS dihedral.
 
 
 # compare Lennard-Jones (LJ) non-bonded equations

--- a/mosdef_gomc/utils/gmso_equation_compare.py
+++ b/mosdef_gomc/utils/gmso_equation_compare.py
@@ -4,10 +4,12 @@ import os
 # import signac
 import xml.etree.ElementTree as ET
 
+import symengine
 import sympy
 import unyt as u
 
-# Although,'symengine.sympify' from 'import symengine ' is faster, it was changed to 'sympy.nsimplify' as it changes
+# Although,'symengine.sympify' from 'import symengine ' is faster, it was changed to 'sympy.nsimplify' for some
+# with the 0.5 decimals in it like as it changes
 # improves the solving of the code by also solving 0.5 or other non-integers with integers.
 
 
@@ -46,7 +48,8 @@ def evaluate_nonbonded_lj_format_with_scaler(new_lj_form, base_lj_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_lj_form) / sympy.nsimplify(base_lj_form),
+                - symengine.sympify(new_lj_form) 
+                / symengine.sympify(base_lj_form),
                 Rmin - sigma * two ** (1 / 6),
                 two - 2,
             ],
@@ -97,8 +100,8 @@ def evaluate_nonbonded_mie_format_with_scaler(new_mie_form, base_mie_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_mie_form)
-                / sympy.nsimplify(base_mie_form),
+                - symengine.sympify(new_mie_form)
+                / symengine.sympify(base_mie_form),
             ],
             [eqn_ratio],
         )
@@ -148,8 +151,8 @@ def evaluate_nonbonded_exp6_format_with_scaler(new_exp6_form, base_exp6_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_exp6_form)
-                / sympy.nsimplify(base_exp6_form),
+                - symengine.sympify(new_exp6_form)
+                / symengine.sympify(base_exp6_form),
             ],
             [eqn_ratio],
         )
@@ -367,8 +370,8 @@ def evaluate_harmonic_bond_format_with_scaler(new_bond_form, base_bond_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_bond_form)
-                / sympy.nsimplify(base_bond_form),
+                - symengine.sympify(new_bond_form)
+                / symengine.sympify(base_bond_form),
             ],
             [eqn_ratio],
         )
@@ -414,8 +417,8 @@ def evaluate_harmonic_angle_format_with_scaler(new_angle_form, base_angle_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_angle_form)
-                / sympy.nsimplify(base_angle_form),
+                - symengine.sympify(new_angle_form)
+                / symengine.sympify(base_angle_form),
             ],
             [eqn_ratio],
         )
@@ -461,8 +464,8 @@ def evaluate_harmonic_torsion_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_torsion_form)
-                / sympy.nsimplify(base_torsion_form),
+                - symengine.sympify(new_torsion_form)
+                / symengine.sympify(base_torsion_form),
             ],
             [eqn_ratio],
         )
@@ -557,8 +560,8 @@ def evaluate_periodic_torsion_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_torsion_form)
-                / sympy.nsimplify(base_torsion_form),
+                - symengine.sympify(new_torsion_form)
+                / symengine.sympify(base_torsion_form),
             ],
             [eqn_ratio],
         )
@@ -604,8 +607,8 @@ def evaluate_RB_torsion_format_with_scaler(new_torsion_form, base_torsion_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_torsion_form)
-                / sympy.nsimplify(base_torsion_form),
+                - symengine.sympify(new_torsion_form)
+                / symengine.sympify(base_torsion_form),
             ],
             [eqn_ratio],
         )
@@ -651,8 +654,8 @@ def evaluate_harmonic_improper_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_improper_form)
-                / sympy.nsimplify(base_improper_form),
+                - symengine.sympify(new_improper_form)
+                / symengine.sympify(base_improper_form),
             ],
             [eqn_ratio],
         )
@@ -698,8 +701,8 @@ def evaluate_periodic_improper_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_improper_form)
-                / sympy.nsimplify(base_improper_form),
+                - symengine.sympify(new_improper_form)
+                / symengine.sympify(base_improper_form),
             ],
             [eqn_ratio],
         )

--- a/mosdef_gomc/utils/gmso_equation_compare.py
+++ b/mosdef_gomc/utils/gmso_equation_compare.py
@@ -46,7 +46,8 @@ def evaluate_nonbonded_lj_format_with_scaler(new_lj_form, base_lj_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_lj_form) / sympy.nsimplify(base_lj_form),
+                - sympy.nsimplify(new_lj_form) 
+                / sympy.nsimplify(base_lj_form),
                 Rmin - sigma * two ** (1 / 6),
                 two - 2,
             ],
@@ -367,8 +368,8 @@ def evaluate_harmonic_bond_format_with_scaler(new_bond_form, base_bond_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - symengine.sympify(new_bond_form)
-                / symengine.sympify(base_bond_form),
+                - sympy.nsimplify(new_bond_form)
+                / sympy.nsimplify(base_bond_form),
             ],
             [eqn_ratio],
         )
@@ -557,8 +558,8 @@ def evaluate_periodic_torsion_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - symengine.sympify(new_torsion_form)
-                / symengine.sympify(base_torsion_form),
+                - sympy.nsimplify(new_torsion_form)
+                / sympy.nsimplify(base_torsion_form),
             ],
             [eqn_ratio],
         )
@@ -604,8 +605,8 @@ def evaluate_RB_torsion_format_with_scaler(new_torsion_form, base_torsion_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - symengine.sympify(new_torsion_form)
-                / symengine.sympify(base_torsion_form),
+                - sympy.nsimplify(new_torsion_form)
+                / sympy.nsimplify(base_torsion_form),
             ],
             [eqn_ratio],
         )
@@ -651,8 +652,8 @@ def evaluate_harmonic_improper_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - symengine.sympify(new_improper_form)
-                / symengine.sympify(base_improper_form),
+                - sympy.nsimplify(new_improper_form)
+                / sympy.nsimplify(base_improper_form),
             ],
             [eqn_ratio],
         )
@@ -698,8 +699,8 @@ def evaluate_periodic_improper_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - symengine.sympify(new_improper_form)
-                / symengine.sympify(base_improper_form),
+                - sympy.nsimplify(new_improper_form)
+                / sympy.nsimplify(base_improper_form),
             ],
             [eqn_ratio],
         )

--- a/mosdef_gomc/utils/gmso_equation_compare.py
+++ b/mosdef_gomc/utils/gmso_equation_compare.py
@@ -46,8 +46,7 @@ def evaluate_nonbonded_lj_format_with_scaler(new_lj_form, base_lj_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_lj_form) 
-                / sympy.nsimplify(base_lj_form),
+                - sympy.nsimplify(new_lj_form) / sympy.nsimplify(base_lj_form),
                 Rmin - sigma * two ** (1 / 6),
                 two - 2,
             ],

--- a/mosdef_gomc/utils/gmso_equation_compare.py
+++ b/mosdef_gomc/utils/gmso_equation_compare.py
@@ -48,7 +48,7 @@ def evaluate_nonbonded_lj_format_with_scaler(new_lj_form, base_lj_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - symengine.sympify(new_lj_form)
+                - symengine.sympify(new_lj_form) 
                 / symengine.sympify(base_lj_form),
                 Rmin - sigma * two ** (1 / 6),
                 two - 2,

--- a/mosdef_gomc/utils/gmso_equation_compare.py
+++ b/mosdef_gomc/utils/gmso_equation_compare.py
@@ -4,10 +4,11 @@ import os
 # import signac
 import xml.etree.ElementTree as ET
 
-import symengine
 import sympy
 import unyt as u
 
+# Although,'symengine.sympify' from 'import symengine ' is faster, it was changed to 'sympy.nsimplify' as it changes
+# improves the solving of the code by also solving 0.5 or other non-integers with integers.
 
 # compare Lennard-Jones (LJ) non-bonded equations
 def evaluate_nonbonded_lj_format_with_scaler(new_lj_form, base_lj_form):
@@ -44,8 +45,8 @@ def evaluate_nonbonded_lj_format_with_scaler(new_lj_form, base_lj_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - symengine.sympify(new_lj_form)
-                / symengine.sympify(base_lj_form),
+                - sympy.nsimplify(new_lj_form)
+                / sympy.nsimplify(base_lj_form),
                 Rmin - sigma * two ** (1 / 6),
                 two - 2,
             ],
@@ -96,8 +97,8 @@ def evaluate_nonbonded_mie_format_with_scaler(new_mie_form, base_mie_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - symengine.sympify(new_mie_form)
-                / symengine.sympify(base_mie_form),
+                - sympy.nsimplify(new_mie_form)
+                / sympy.nsimplify(base_mie_form),
             ],
             [eqn_ratio],
         )
@@ -147,8 +148,8 @@ def evaluate_nonbonded_exp6_format_with_scaler(new_exp6_form, base_exp6_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - symengine.sympify(new_exp6_form)
-                / symengine.sympify(base_exp6_form),
+                - sympy.nsimplify(new_exp6_form)
+                / sympy.nsimplify(base_exp6_form),
             ],
             [eqn_ratio],
         )
@@ -413,8 +414,8 @@ def evaluate_harmonic_angle_format_with_scaler(new_angle_form, base_angle_form):
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - symengine.sympify(new_angle_form)
-                / symengine.sympify(base_angle_form),
+                - sympy.nsimplify(new_angle_form)
+                / sympy.nsimplify(base_angle_form),
             ],
             [eqn_ratio],
         )
@@ -460,8 +461,8 @@ def evaluate_harmonic_torsion_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - symengine.sympify(new_torsion_form)
-                / symengine.sympify(base_torsion_form),
+                - sympy.nsimplify(new_torsion_form)
+                / sympy.nsimplify(base_torsion_form),
             ],
             [eqn_ratio],
         )
@@ -509,8 +510,8 @@ def evaluate_OPLS_torsion_format_with_scaler(
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - symengine.sympify(new_torsion_form)
-                / symengine.sympify(base_torsion_form),
+                - sympy.nsimplify(new_torsion_form)
+                / sympy.nsimplify(base_torsion_form),
             ],
             [eqn_ratio],
         )


### PR DESCRIPTION
'symengine.sympify' changed to  'sympy.nsimplify' to solve for non-integers

Although,'symengine.sympify' from 'import symengine ' is faster, it was changed to 'sympy.nsimplify' as it changes
- improves the solving of the code by also solving 0.5 or other non-integers with integers.