### PR TITLE
Need to lock GSD at gsd =3.3.2 until it is compatible (and others) with NumPy=>2.x

### DIFF
--- a/docs/environment_docs.yml
+++ b/docs/environment_docs.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - garnett
-  - gsd
+  - gsd=3.3.2
   - ipython
   - numpydoc
   - mock

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - garnett
-  - gsd
+  - gsd=3.3.2
   - ipython
   - numpydoc
   - mock


### PR DESCRIPTION
Need to lock GSD at gsd =3.3.2 until it is compatible (and others) with NumPy=>2.x