### PR TITLE
lock GMSO to version 0.14.0

### DIFF
--- a/docs/environment_docs.yml
+++ b/docs/environment_docs.yml
@@ -18,11 +18,11 @@ dependencies:
   - sympy
   - symengine
   - python-symengine
-  - python>=3.10,<3.12
-  - forcefield-utilities>=0.3.0
-  - foyer>=0.12.1
-  - gmso>=0.12.4
-  - mbuild>=0.17.1
+  - python>=3.12,<3.14
+  - forcefield-utilities>=0.4.0
+  - foyer>=1.0.1
+  - gmso=0.14.0
+  - mbuild>=1.2.1
   - pre-commit
   - sphinx=6.1.1
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - python>=3.12,<3.14
   - forcefield-utilities>=0.4.0
   - foyer>=1.0.1
-  - gmso>=0.14.0
+  - gmso=0.14.0
   - mbuild>=1.2.1
   - pre-commit
   - sphinx=6.1.1


### PR DESCRIPTION
lock to GMSO version 0.14.0 as version 0.15.0 does not allow the creation of empty boxes in dual box systems.

A ticket was put in for this on GMSO GitHub